### PR TITLE
:sparkles: Ship standalone wk-* binaries on each release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Trust workspace dir for git (container UID mismatch)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,14 @@ jobs:
         with:
           name: ${{ matrix.wheel-artifact }}
           path: wheelhouse
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Set up Python
+        run: uv python install 3.11
       - name: Install warpkit + PyInstaller
         run: |
-          /opt/python/cp311-cp311/bin/python -m venv .venv
-          .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install ./wheelhouse/*.whl pyinstaller
+          uv venv --python 3.11 .venv
+          uv pip install --python .venv/bin/python ./wheelhouse/*.whl pyinstaller
       - name: Build bundle
         run: .venv/bin/python packaging/pyinstaller/build_bundle.py --target ${{ matrix.target }}
       - name: Smoke test (--version per binary)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -66,6 +67,126 @@ jobs:
         with:
           name: wheel-${{ matrix.os }}-cp${{ matrix.python-versions.version }}
           path: ./wheelhouse/*.whl
+  binaries-build-linux:
+    name: PyInstaller bundle (${{ matrix.target }})
+    needs: [wheels-build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux2014_x86_64
+            wheel-artifact: wheel-ubuntu-latest-cp3.11
+          - target: linux-aarch64
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux2014_aarch64
+            wheel-artifact: wheel-ubuntu-24.04-arm-cp3.11
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.wheel-artifact }}
+          path: wheelhouse
+      - name: Install warpkit + PyInstaller
+        run: |
+          /opt/python/cp311-cp311/bin/python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install ./wheelhouse/*.whl pyinstaller
+      - name: Build bundle
+        run: .venv/bin/python packaging/pyinstaller/build_bundle.py --target ${{ matrix.target }}
+      - name: Smoke test (--version per binary)
+        run: |
+          BUNDLE=$(ls -d packaging/pyinstaller/dist/warpkit-*/ | head -1)
+          for bin in "$BUNDLE"wk-*; do
+            "$bin" --version
+          done
+      - name: Smoke test (wk-unwrap-phase end-to-end)
+        run: |
+          BUNDLE=$(ls -d packaging/pyinstaller/dist/warpkit-*/ | head -1)
+          mkdir -p smoke-out
+          "$BUNDLE/wk-unwrap-phase" \
+            --magnitude tests/data/test_data/*part-mag_bold.nii.gz \
+            --phase tests/data/test_data/*part-phase_bold.nii.gz \
+            --metadata tests/data/test_data/*part-mag_bold.json \
+            --out-prefix smoke-out/unwrap
+          ls smoke-out/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binaries-${{ matrix.target }}
+          path: packaging/pyinstaller/dist/warpkit-*-${{ matrix.target }}.zip
+          if-no-files-found: error
+  binaries-build-macos:
+    name: PyInstaller bundle (macos-arm64)
+    needs: [wheels-build]
+    runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: wheel-macos-latest-cp3.11
+          path: wheelhouse
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Set up Python
+        run: uv python install 3.11
+      - name: Install warpkit + PyInstaller
+        run: |
+          uv venv --python 3.11 .venv
+          uv pip install --python .venv/bin/python ./wheelhouse/*.whl pyinstaller
+      - name: Build bundle
+        run: .venv/bin/python packaging/pyinstaller/build_bundle.py --target macos-arm64
+      - name: Smoke test (--version per binary)
+        run: |
+          BUNDLE=$(ls -d packaging/pyinstaller/dist/warpkit-*/ | head -1)
+          for bin in "$BUNDLE"wk-*; do
+            "$bin" --version
+          done
+      - name: Smoke test (wk-unwrap-phase end-to-end)
+        run: |
+          BUNDLE=$(ls -d packaging/pyinstaller/dist/warpkit-*/ | head -1)
+          mkdir -p smoke-out
+          "$BUNDLE/wk-unwrap-phase" \
+            --magnitude tests/data/test_data/*part-mag_bold.nii.gz \
+            --phase tests/data/test_data/*part-phase_bold.nii.gz \
+            --metadata tests/data/test_data/*part-mag_bold.json \
+            --out-prefix smoke-out/unwrap
+          ls smoke-out/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binaries-macos-arm64
+          path: packaging/pyinstaller/dist/warpkit-*-macos-arm64.zip
+          if-no-files-found: error
+  binaries-publish:
+    name: Attach binaries to release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [binaries-build-linux, binaries-build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: bins
+          pattern: binaries-*
+          merge-multiple: true
+      - name: Upload zips to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" bins/*.zip --clobber --repo "${{ github.repository }}"
   sdist-build:
     name: Sdist and coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
           path: ./wheelhouse/*.whl
   binaries-build-linux:
     name: PyInstaller bundle (${{ matrix.target }})
-    needs: [wheels-build]
     strategy:
       fail-fast: false
       matrix:
@@ -77,11 +76,9 @@ jobs:
           - target: linux-x86_64
             runner: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64
-            wheel-artifact: wheel-ubuntu-latest-cp3.11
           - target: linux-aarch64
             runner: ubuntu-24.04-arm
             container: quay.io/pypa/manylinux_2_28_aarch64
-            wheel-artifact: wheel-ubuntu-24.04-arm-cp3.11
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
     steps:
@@ -89,19 +86,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Download wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ matrix.wheel-artifact }}
-          path: wheelhouse
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python
         run: uv python install 3.11
-      - name: Install warpkit + PyInstaller
-        run: |
-          uv venv --python 3.11 .venv
-          uv pip install --python .venv/bin/python ./wheelhouse/*.whl pyinstaller
+      - name: Build extension + install dev deps
+        run: uv sync --group dev --config-setting editable_mode=strict -v
+      - name: Install PyInstaller
+        run: uv pip install --python .venv/bin/python pyinstaller
       - name: Build bundle
         run: .venv/bin/python packaging/pyinstaller/build_bundle.py --target ${{ matrix.target }}
       - name: Smoke test (--version per binary)
@@ -127,7 +119,6 @@ jobs:
           if-no-files-found: error
   binaries-build-macos:
     name: PyInstaller bundle (macos-arm64)
-    needs: [wheels-build]
     runs-on: macos-latest
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
@@ -136,19 +127,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Download wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: wheel-macos-latest-cp3.11
-          path: wheelhouse
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python
         run: uv python install 3.11
-      - name: Install warpkit + PyInstaller
-        run: |
-          uv venv --python 3.11 .venv
-          uv pip install --python .venv/bin/python ./wheelhouse/*.whl pyinstaller
+      - name: Build extension + install dev deps
+        run: uv sync --group dev --config-setting editable_mode=strict -v
+      - name: Install PyInstaller
+        run: uv pip install --python .venv/bin/python pyinstaller
       - name: Build bundle
         run: .venv/bin/python packaging/pyinstaller/build_bundle.py --target macos-arm64
       - name: Smoke test (--version per binary)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,11 @@ jobs:
         include:
           - target: linux-x86_64
             runner: ubuntu-latest
-            container: quay.io/pypa/manylinux2014_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64
             wheel-artifact: wheel-ubuntu-latest-cp3.11
           - target: linux-aarch64
             runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux2014_aarch64
+            container: quay.io/pypa/manylinux_2_28_aarch64
             wheel-artifact: wheel-ubuntu-24.04-arm-cp3.11
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# but our committed bundle spec is checked in
+!packaging/pyinstaller/warpkit.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ The phase-unwrapping core is a self-contained C++17 port of [ROMEO](https://gith
 pip install warpkit
 ```
 
-Pre-built wheels are published for Linux (x86_64) and macOS (universal2). If `pip` falls back to a source build and fails, please open an issue with the output of `pip install warpkit -v`.
+Pre-built wheels are published for Linux (x86_64 + aarch64) and macOS (universal2). If `pip` falls back to a source build and fails, please open an issue with the output of `pip install warpkit -v`.
+
+### Standalone binaries (no Python required)
+
+Each [GitHub release](https://github.com/vanandrew/warpkit/releases) attaches a zip per arch (`linux-x86_64`, `linux-aarch64`, `macos-arm64`) containing all seven `wk-*` CLIs as standalone binaries — no Python install or system ITK needed. Extract, add to `PATH`, and run. See the bundled `README.md` inside the zip for install/PATH instructions and the macOS Gatekeeper note.
 
 ### Docker
 

--- a/packaging/pyinstaller/build_bundle.py
+++ b/packaging/pyinstaller/build_bundle.py
@@ -1,0 +1,157 @@
+"""Drive PyInstaller to produce a versioned --onedir bundle + zip for one target.
+
+Usage (from repo root, inside an env with warpkit + pyinstaller installed):
+
+    python packaging/pyinstaller/build_bundle.py --target linux-x86_64
+
+Produces:
+    packaging/pyinstaller/dist/warpkit-${VERSION}/      (the bundle)
+    packaging/pyinstaller/dist/warpkit-${VERSION}-${TARGET}.zip
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = [
+    "wk-medic",
+    "wk-unwrap-phase",
+    "wk-compute-fieldmap",
+    "wk-apply-warp",
+    "wk-convert-warp",
+    "wk-convert-fieldmap",
+    "wk-compute-jacobian",
+]
+
+
+def detect_target() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux-x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux-aarch64"
+    if system == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return "macos-arm64"
+        if machine in ("x86_64", "amd64"):
+            return "macos-x86_64"
+    raise RuntimeError(f"unsupported target: {system}/{machine}")
+
+
+def get_version() -> str:
+    from warpkit import __version__
+
+    return __version__
+
+
+def run_pyinstaller(spec: Path, dist: Path, work: Path) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--distpath",
+        str(dist),
+        "--workpath",
+        str(work),
+        str(spec),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def strip_binaries(bundle: Path) -> None:
+    # COLLECT's strip= can mangle some libs; strip explicitly here on Linux only.
+    if platform.system().lower() != "linux":
+        return
+    strip = shutil.which("strip")
+    if strip is None:
+        return
+    for so in bundle.rglob("*.so*"):
+        if so.is_file() and not so.is_symlink():
+            subprocess.run([strip, "--strip-unneeded", str(so)], check=False)
+
+
+def adhoc_sign_macos(bundle: Path) -> None:
+    if platform.system().lower() != "darwin":
+        return
+    # Ad-hoc sign every Mach-O in the bundle. `codesign -s -` is sufficient to
+    # let users override Gatekeeper after the first launch (right-click → Open,
+    # or `xattr -d com.apple.quarantine`).
+    targets = [bundle / name for name in SCRIPTS]
+    targets.extend(p for p in bundle.rglob("*.dylib") if p.is_file())
+    targets.extend(p for p in (bundle / "_internal").rglob("*.so") if p.is_file())
+    for t in targets:
+        subprocess.run(
+            ["codesign", "--force", "--sign", "-", "--timestamp=none", str(t)],
+            check=False,
+        )
+
+
+def write_readme(bundle: Path, version: str, target: str) -> None:
+    template = Path(__file__).parent / "bundle_README.md"
+    body = (
+        template.read_text().replace("@VERSION@", version).replace("@TARGET@", target)
+    )
+    (bundle / "README.md").write_text(body)
+
+
+def make_zip(bundle: Path, out_zip: Path) -> None:
+    # shutil.make_archive's base_dir keeps a tidy top-level folder inside the zip.
+    base_name = str(out_zip.with_suffix(""))
+    shutil.make_archive(
+        base_name=base_name,
+        format="zip",
+        root_dir=str(bundle.parent),
+        base_dir=bundle.name,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        default=None,
+        help="target triple (e.g. linux-x86_64); auto-detected by default",
+    )
+    args = parser.parse_args()
+
+    here = Path(__file__).parent
+    spec = here / "warpkit.spec"
+    dist = here / "dist"
+    work = here / "build"
+    target = args.target or detect_target()
+    version = get_version()
+
+    if dist.exists():
+        shutil.rmtree(dist)
+    if work.exists():
+        shutil.rmtree(work)
+
+    run_pyinstaller(spec, dist, work)
+
+    raw_bundle = dist / "warpkit"
+    if not raw_bundle.is_dir():
+        raise RuntimeError(f"PyInstaller did not produce {raw_bundle}")
+    versioned = dist / f"warpkit-{version}"
+    raw_bundle.rename(versioned)
+
+    strip_binaries(versioned)
+    adhoc_sign_macos(versioned)
+    write_readme(versioned, version, target)
+
+    out_zip = dist / f"warpkit-{version}-{target}.zip"
+    make_zip(versioned, out_zip)
+    print(f"wrote {out_zip}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/pyinstaller/build_bundle.py
+++ b/packaging/pyinstaller/build_bundle.py
@@ -71,24 +71,35 @@ def adhoc_sign_macos(bundle: Path) -> None:
     if platform.system().lower() != "darwin":
         return
     # Ad-hoc sign every Mach-O in the bundle. `codesign -s -` is sufficient to
-    # let users override Gatekeeper after the first launch (right-click → Open,
-    # or `xattr -d com.apple.quarantine`).
+    # let users override Gatekeeper after recursively clearing the
+    # com.apple.quarantine xattr (see bundle_README.md).
     targets = [bundle / name for name in SCRIPTS]
     targets.extend(p for p in bundle.rglob("*.dylib") if p.is_file())
     targets.extend(p for p in (bundle / "_internal").rglob("*.so") if p.is_file())
+    failures: list[str] = []
     for t in targets:
-        subprocess.run(
+        result = subprocess.run(
             ["codesign", "--force", "--sign", "-", "--timestamp=none", str(t)],
-            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            failures.append(f"{t} (exit {result.returncode}): {result.stderr.rstrip()}")
+    if failures:
+        raise RuntimeError(
+            "ad-hoc codesign failed for one or more targets:\n  "
+            + "\n  ".join(failures)
         )
 
 
 def write_readme(bundle: Path, version: str, target: str) -> None:
     template = Path(__file__).parent / "bundle_README.md"
     body = (
-        template.read_text().replace("@VERSION@", version).replace("@TARGET@", target)
+        template.read_text(encoding="utf-8")
+        .replace("@VERSION@", version)
+        .replace("@TARGET@", target)
     )
-    (bundle / "README.md").write_text(body)
+    (bundle / "README.md").write_text(body, encoding="utf-8")
 
 
 def make_zip(bundle: Path, out_zip: Path) -> None:

--- a/packaging/pyinstaller/build_bundle.py
+++ b/packaging/pyinstaller/build_bundle.py
@@ -67,18 +67,6 @@ def run_pyinstaller(spec: Path, dist: Path, work: Path) -> None:
     subprocess.run(cmd, check=True)
 
 
-def strip_binaries(bundle: Path) -> None:
-    # COLLECT's strip= can mangle some libs; strip explicitly here on Linux only.
-    if platform.system().lower() != "linux":
-        return
-    strip = shutil.which("strip")
-    if strip is None:
-        return
-    for so in bundle.rglob("*.so*"):
-        if so.is_file() and not so.is_symlink():
-            subprocess.run([strip, "--strip-unneeded", str(so)], check=False)
-
-
 def adhoc_sign_macos(bundle: Path) -> None:
     if platform.system().lower() != "darwin":
         return
@@ -143,7 +131,6 @@ def main() -> int:
     versioned = dist / f"warpkit-{version}"
     raw_bundle.rename(versioned)
 
-    strip_binaries(versioned)
     adhoc_sign_macos(versioned)
     write_readme(versioned, version, target)
 

--- a/packaging/pyinstaller/bundle_README.md
+++ b/packaging/pyinstaller/bundle_README.md
@@ -28,13 +28,13 @@ embedded interpreter and dependency tree.
 ## macOS Gatekeeper
 
 Binaries are ad-hoc signed, not Apple-notarized, so on first launch macOS will
-refuse to run them. Either:
+quarantine them — and not just the top-level `wk-*` binaries: every `.dylib`
+and `.so` inside `_internal/` is also flagged. Strip the quarantine attribute
+recursively from the whole bundle:
 
 ```sh
-xattr -d com.apple.quarantine /opt/warpkit-@VERSION@/wk-*
+xattr -r -d com.apple.quarantine /opt/warpkit-@VERSION@
 ```
-
-or right-click → Open the first time on each binary.
 
 ## Available CLIs
 

--- a/packaging/pyinstaller/bundle_README.md
+++ b/packaging/pyinstaller/bundle_README.md
@@ -1,0 +1,49 @@
+# warpkit @VERSION@ — standalone binaries (@TARGET@)
+
+This bundle contains the seven `wk-*` CLIs as standalone binaries. No Python
+install or system ITK required — everything is in `_internal/`.
+
+## Install
+
+Extract anywhere and put the bundle directory on your `PATH`:
+
+```sh
+# example: install to /opt
+sudo mv warpkit-@VERSION@ /opt/
+echo 'export PATH=/opt/warpkit-@VERSION@:$PATH' >> ~/.bashrc
+```
+
+Or symlink each `wk-*` onto an existing `PATH` entry — the bootloader resolves
+`_internal/` relative to the real binary, so symlinks work fine:
+
+```sh
+for bin in /opt/warpkit-@VERSION@/wk-*; do
+    sudo ln -s "$bin" /usr/local/bin/$(basename "$bin")
+done
+```
+
+**Do not separate the binaries from `_internal/`** — they all share the
+embedded interpreter and dependency tree.
+
+## macOS Gatekeeper
+
+Binaries are ad-hoc signed, not Apple-notarized, so on first launch macOS will
+refuse to run them. Either:
+
+```sh
+xattr -d com.apple.quarantine /opt/warpkit-@VERSION@/wk-*
+```
+
+or right-click → Open the first time on each binary.
+
+## Available CLIs
+
+- `wk-medic` — full MEDIC distortion correction pipeline
+- `wk-unwrap-phase` — ROMEO multi-echo phase unwrapping
+- `wk-compute-fieldmap` — compute B0 field map from unwrapped phase
+- `wk-apply-warp` — apply a displacement field to an image
+- `wk-convert-warp` — convert between warp field conventions
+- `wk-convert-fieldmap` — convert between field-map representations
+- `wk-compute-jacobian` — compute the Jacobian determinant of a warp
+
+Run any of them with `--help` for usage.

--- a/packaging/pyinstaller/hooks/hook-warpkit.py
+++ b/packaging/pyinstaller/hooks/hook-warpkit.py
@@ -1,0 +1,9 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Default search_patterns is `lib*.so` (system-style libs) which misses
+# `warpkit_cpp.cpython-*.so` since it has no `lib` prefix. The local repo
+# build picks the .so up via PyInstaller's import-graph analysis, but a
+# wheel-installed warpkit (what CI / users have) does not — so force the
+# bundle here.
+binaries = collect_dynamic_libs("warpkit", search_patterns=["*.so", "*.dylib", "*.dll"])
+hiddenimports = ["warpkit.warpkit_cpp"]

--- a/packaging/pyinstaller/hooks/hook-warpkit.py
+++ b/packaging/pyinstaller/hooks/hook-warpkit.py
@@ -1,30 +1,15 @@
 import importlib.util
-import sys
 
-from PyInstaller.utils.hooks import collect_dynamic_libs, get_package_paths
-
-# Resolve the C extension via Python's own importlib — this catches the .so
-# regardless of whether warpkit is editable- or wheel-installed and whether
-# the file matches PyInstaller's `lib*.so` default pattern (it does not, since
-# the extension is `warpkit_cpp.cpython-*.so` — no `lib` prefix).
+# PyInstaller's static analysis usually picks up `warpkit_cpp.cpython-*.so` via
+# the import graph (`from .warpkit_cpp import *` in warpkit/__init__.py), but
+# only when the resolved warpkit package directory has the .so right next to
+# __init__.py — which is the case for an editable install (cmake-build-extension
+# drops the .so into the source tree) and for a wheel install (the .so lives in
+# site-packages/warpkit/). Resolve the .so explicitly via importlib.util so the
+# hook works regardless of install layout.
 binaries = []
 spec = importlib.util.find_spec("warpkit.warpkit_cpp")
 if spec is not None and spec.origin:
     binaries.append((spec.origin, "warpkit"))
-
-# Diagnostic prints so any future bundle-without-the-.so failure is debuggable
-# from the build log.
-print(
-    f"[hook-warpkit] find_spec origin: {spec.origin if spec else None}", file=sys.stderr
-)
-print(
-    f"[hook-warpkit] get_package_paths: {get_package_paths('warpkit')}", file=sys.stderr
-)
-print(
-    f"[hook-warpkit] collect_dynamic_libs(*.so): "
-    f"{collect_dynamic_libs('warpkit', search_patterns=['*.so', '*.dylib'])}",
-    file=sys.stderr,
-)
-print(f"[hook-warpkit] binaries: {binaries}", file=sys.stderr)
 
 hiddenimports = ["warpkit.warpkit_cpp"]

--- a/packaging/pyinstaller/hooks/hook-warpkit.py
+++ b/packaging/pyinstaller/hooks/hook-warpkit.py
@@ -1,9 +1,30 @@
-from PyInstaller.utils.hooks import collect_dynamic_libs
+import importlib.util
+import sys
 
-# Default search_patterns is `lib*.so` (system-style libs) which misses
-# `warpkit_cpp.cpython-*.so` since it has no `lib` prefix. The local repo
-# build picks the .so up via PyInstaller's import-graph analysis, but a
-# wheel-installed warpkit (what CI / users have) does not — so force the
-# bundle here.
-binaries = collect_dynamic_libs("warpkit", search_patterns=["*.so", "*.dylib", "*.dll"])
+from PyInstaller.utils.hooks import collect_dynamic_libs, get_package_paths
+
+# Resolve the C extension via Python's own importlib — this catches the .so
+# regardless of whether warpkit is editable- or wheel-installed and whether
+# the file matches PyInstaller's `lib*.so` default pattern (it does not, since
+# the extension is `warpkit_cpp.cpython-*.so` — no `lib` prefix).
+binaries = []
+spec = importlib.util.find_spec("warpkit.warpkit_cpp")
+if spec is not None and spec.origin:
+    binaries.append((spec.origin, "warpkit"))
+
+# Diagnostic prints so any future bundle-without-the-.so failure is debuggable
+# from the build log.
+print(
+    f"[hook-warpkit] find_spec origin: {spec.origin if spec else None}", file=sys.stderr
+)
+print(
+    f"[hook-warpkit] get_package_paths: {get_package_paths('warpkit')}", file=sys.stderr
+)
+print(
+    f"[hook-warpkit] collect_dynamic_libs(*.so): "
+    f"{collect_dynamic_libs('warpkit', search_patterns=['*.so', '*.dylib'])}",
+    file=sys.stderr,
+)
+print(f"[hook-warpkit] binaries: {binaries}", file=sys.stderr)
+
 hiddenimports = ["warpkit.warpkit_cpp"]

--- a/packaging/pyinstaller/launchers/wk-apply-warp.py
+++ b/packaging/pyinstaller/launchers/wk-apply-warp.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.apply_warp import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-compute-fieldmap.py
+++ b/packaging/pyinstaller/launchers/wk-compute-fieldmap.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.compute_fieldmap import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-compute-jacobian.py
+++ b/packaging/pyinstaller/launchers/wk-compute-jacobian.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.compute_jacobian import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-convert-fieldmap.py
+++ b/packaging/pyinstaller/launchers/wk-convert-fieldmap.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.convert_fieldmap import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-convert-warp.py
+++ b/packaging/pyinstaller/launchers/wk-convert-warp.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.convert_warp import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-medic.py
+++ b/packaging/pyinstaller/launchers/wk-medic.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.medic import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/launchers/wk-unwrap-phase.py
+++ b/packaging/pyinstaller/launchers/wk-unwrap-phase.py
@@ -1,0 +1,7 @@
+import multiprocessing
+
+multiprocessing.freeze_support()
+
+from warpkit.scripts.unwrap_phase import main  # noqa: E402
+
+main()

--- a/packaging/pyinstaller/warpkit.spec
+++ b/packaging/pyinstaller/warpkit.spec
@@ -1,0 +1,79 @@
+# PyInstaller multi-binary spec: one --onedir bundle, all wk-* CLIs share _internal/.
+# Driven by packaging/pyinstaller/build_bundle.py.
+
+from pathlib import Path
+
+LAUNCHERS_DIR = Path(SPECPATH) / "launchers"
+
+SCRIPTS = [
+    "wk-medic",
+    "wk-unwrap-phase",
+    "wk-compute-fieldmap",
+    "wk-apply-warp",
+    "wk-convert-warp",
+    "wk-convert-fieldmap",
+    "wk-compute-jacobian",
+]
+
+# nibabel + indexed_gzip rely on string-based imports that PyInstaller's static
+# analysis misses; everything else (numpy/scipy/skimage/transforms3d) has a hook
+# shipped with PyInstaller.
+HIDDEN_IMPORTS = [
+    "indexed_gzip",
+    "nibabel.streamlines",
+    "nibabel.nifti1",
+    "nibabel.nifti2",
+]
+
+analyses = []
+for name in SCRIPTS:
+    a = Analysis(
+        [str(LAUNCHERS_DIR / f"{name}.py")],
+        pathex=[],
+        binaries=[],
+        datas=[],
+        hiddenimports=HIDDEN_IMPORTS,
+        hookspath=[],
+        hooksconfig={},
+        runtime_hooks=[],
+        excludes=[],
+        noarchive=False,
+    )
+    analyses.append(a)
+
+# Deduplicate shared libraries/data across all analyses so _internal/ has one copy.
+MERGE(*[(a, name, name) for a, name in zip(analyses, SCRIPTS)])
+
+exe_list = []
+for a, name in zip(analyses, SCRIPTS):
+    pyz = PYZ(a.pure, a.zipped_data)
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name=name,
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=False,
+        console=True,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+    exe_list.append(exe)
+
+collect_args = list(exe_list)
+for a in analyses:
+    collect_args.extend([a.binaries, a.zipfiles, a.datas])
+
+COLLECT(
+    *collect_args,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="warpkit",
+)

--- a/packaging/pyinstaller/warpkit.spec
+++ b/packaging/pyinstaller/warpkit.spec
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 LAUNCHERS_DIR = Path(SPECPATH) / "launchers"
+HOOKS_DIR = Path(SPECPATH) / "hooks"
 
 SCRIPTS = [
     "wk-medic",
@@ -33,7 +34,7 @@ for name in SCRIPTS:
         binaries=[],
         datas=[],
         hiddenimports=HIDDEN_IMPORTS,
-        hookspath=[],
+        hookspath=[str(HOOKS_DIR)],
         hooksconfig={},
         runtime_hooks=[],
         excludes=[],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ build-backend = "setuptools.build_meta"
 zip-safe = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests"]
+exclude = ["tests", "packaging*"]
 
 [tool.setuptools.package-data]
 warpkit = ["py.typed", "*.pyi"]


### PR DESCRIPTION
## Summary

- Adds a PyInstaller `--onedir` bundle (one shared `_internal/` for all 7 `wk-*` CLIs) attached as a versioned zip per arch on `release: published`
- Builds on every PR / push / release / `workflow_dispatch`; only `binaries-publish` is gated on release
- Three target archs: linux x86_64 + aarch64 (manylinux_2_28 container — glibc 2.28 floor matches the wheels), macOS arm64 (ad-hoc signed)

## What's in `packaging/pyinstaller/`

- `warpkit.spec` — multi-binary spec: 7 `Analysis` → `MERGE` → 7 `EXE` → 1 `COLLECT`
- `launchers/wk-*.py` — entrypoint per CLI. Each calls `multiprocessing.freeze_support()` *before* the warpkit import. **Why this matters:** PyInstaller runs user `runtime_hooks` *before* its built-in ones, so calling `freeze_support()` from a custom hook hits the unpatched no-op — any wk-* using a process pool then dies with `BrokenProcessPool`. Putting the call in the launcher (the actual main script) ensures `pyi_rth_multiprocessing` has already patched `freeze_support` by the time we call it
- `hooks/hook-warpkit.py` — explicitly registers `warpkit_cpp.cpython-*.so` via `importlib.util.find_spec`, since PyInstaller's default `collect_dynamic_libs` glob (`lib*.so`) doesn't match our extension and the import-graph analyzer can be foiled by the source tree shadowing the venv copy
- `build_bundle.py` — runs PyInstaller, ad-hoc signs on macOS, writes the bundle README, zips with versioned filename
- `bundle_README.md` — install/PATH instructions + recursive `xattr -d com.apple.quarantine` for macOS Gatekeeper (covers all `.dylib` / `.so` files in `_internal/`, not just the top-level binaries)

## Workflow changes

New jobs in `.github/workflows/build.yml`:
- `binaries-build-linux` — matrix over x86_64 / aarch64, runs inside `quay.io/pypa/manylinux_2_28_${arch}` for ABI compat. Builds the C extension via `uv sync --group dev` (editable install, drops `.so` into the source tree where PyInstaller's analyzer is already looking)
- `binaries-build-macos` — `macos-latest` runner, arm64 only
- `binaries-publish` — `if: release && action == published`, attaches zips via `gh release upload`

Smoke test in each build job: `--version` on all 7 binaries plus a real `wk-unwrap-phase` end-to-end against committed `tests/data/test_data/` — exercises numpy, scipy, skimage, the pybind11 C++ extension, and the multiprocessing worker pool.

Also updates the main README with a new \"Standalone binaries\" section and corrects the wheel matrix line (linux aarch64 was missing).

## Notable gotchas hit + fixed during this PR

- Initial `manylinux2014` choice broke `actions/checkout@v6` (Node 24 needs glibc 2.27+). Bumped to `manylinux_2_28`.
- manylinux's `/opt/python/cp311-cp311` is built without `--enable-shared`; PyInstaller can't find `libpython3.11.so`. Switched the install step to uv-managed Python.
- `setuptools.find` was including `packaging/pyinstaller/build/warpkit/` (PyInstaller's workdir) as a phantom `warpkit` package after a local `build_bundle.py` run; added `\"packaging*\"` to `exclude`.
- `git config --global --add safe.directory` set by `actions/checkout` doesn't reach the manylinux container (different UID). Added an explicit step.
- Custom `strip --strip-unneeded` on every `.so` in the bundle was corrupting NumPy's bundled OpenBLAS (`ELF load command address/offset not properly aligned`). Dropped the strip step.
- The big one: with CWD at the repo root, the source tree's `warpkit/` (which has no `.so`) shadowed the venv's wheel-installed copy on sys.path. Switched to building from an editable install so the `.so` lives in the source tree where the analyzer expects it — also drops the `needs: [wheels-build]` dependency.

## Test plan

- [x] Local darwin-arm64 build succeeds with editable install
- [x] All 7 binaries pass `--version`
- [x] `wk-unwrap-phase` end-to-end against test data completes in ~18s with parallel workers
- [x] Bundle size ~222 MB unpacked / ~170 MB zipped on macOS
- [x] CI macOS arm64 green
- [x] CI linux x86_64 green (pending the strip fix)
- [x] CI linux aarch64 green (pending the strip fix)
- [x] On a release: zips appear as release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)