### PR TITLE
:fire: Drop WARPKIT_DEV escape hatch in favor of cmake build cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export FETCHCONTENT_BASE_DIR="$HOME/.cache/warpkit-fetchcontent"
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,12 +53,21 @@ uv run pytest -q
 
 `uv sync` invokes the build backend in a fresh tempdir each time, so by
 default CMake re-fetches and re-builds ITK from scratch on every sync.
-Two env vars cut that down to seconds for incremental work:
+The repo ships an `.envrc` that sets two env vars to cut this down to
+seconds for incremental work:
 
 ```bash
-# brew install ccache  (or apt install ccache, etc.)
-export FETCHCONTENT_BASE_DIR=$HOME/.cache/warpkit-fetchcontent
+# .envrc
+export FETCHCONTENT_BASE_DIR="$HOME/.cache/warpkit-fetchcontent"
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+```
+
+To pick it up automatically on `cd` into the repo, install [direnv](https://direnv.net):
+
+```bash
+brew install direnv ccache         # or apt / dnf equivalents
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc   # or bash, fish, etc.
+direnv allow                        # one-time approval for this repo
 ```
 
 `FETCHCONTENT_BASE_DIR` survives the tempdir churn, so ITK is fetched
@@ -67,6 +76,11 @@ the same ITK files in a fresh build dir is a cache hit. CMake still
 re-*configures* per sync (no way to avoid that without a persistent
 build dir, which setuptools / PEP-517 doesn't expose), but the heavy
 download + compile work is amortized.
+
+Without direnv, source the file manually (`source .envrc`) before
+running `uv sync` — VS Code's `terminal.integrated.env.*` setting is
+not reliable here because Claude Code / extension-spawned shells often
+bypass it.
 
 ```bash
 # coverage (matches the CI `coverage` job)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,28 @@ uv sync --group dev --config-setting editable_mode=strict
 
 # tests
 uv run pytest -q
+```
 
+### Speeding up `uv sync` rebuilds
+
+`uv sync` invokes the build backend in a fresh tempdir each time, so by
+default CMake re-fetches and re-builds ITK from scratch on every sync.
+Two env vars cut that down to seconds for incremental work:
+
+```bash
+# brew install ccache  (or apt install ccache, etc.)
+export FETCHCONTENT_BASE_DIR=$HOME/.cache/warpkit-fetchcontent
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+```
+
+`FETCHCONTENT_BASE_DIR` survives the tempdir churn, so ITK is fetched
++ extracted once total. `ccache` hashes compiler inputs, so re-compiling
+the same ITK files in a fresh build dir is a cache hit. CMake still
+re-*configures* per sync (no way to avoid that without a persistent
+build dir, which setuptools / PEP-517 doesn't expose), but the heavy
+download + compile work is amortized.
+
+```bash
 # coverage (matches the CI `coverage` job)
 uv run coverage run && uv run coverage report -m
 

--- a/warpkit/__init__.py
+++ b/warpkit/__init__.py
@@ -1,27 +1,7 @@
-import os
-
 try:
     from ._version import __version__, __version_tuple__
 except ImportError:
     __version__ = "0.0.0+unknown"
     __version_tuple__ = (0, 0, 0, "unknown", "")
 
-if os.environ.get("WARPKIT_DEV", False) == "1":
-    from warnings import warn
-
-    warn(
-        "WARPKIT_DEV is set, trying to load from repo root build directory instead...",
-        stacklevel=2,
-    )
-    import sys
-    from pathlib import Path
-
-    BUILD_DIR = str(Path(__file__).parent.parent / "build")
-    sys.path.append(BUILD_DIR)
-    from warpkit_cpp import *  # type: ignore  # noqa: F403
-
-    warn(
-        "Successfully loaded warpkit_cpp from repo root build directory!", stacklevel=2
-    )
-else:
-    from .warpkit_cpp import *  # noqa: F403
+from .warpkit_cpp import *  # noqa: F403


### PR DESCRIPTION
## Summary

- Remove the `WARPKIT_DEV=1` branch in [warpkit/__init__.py](warpkit/__init__.py) — it pointed `import warpkit` at a manual `cmake -B build` build to skirt slow `uv sync` rebuilds; `FETCHCONTENT_BASE_DIR` + `ccache` does the same job without forking the import path.
- Document the cache env vars in [CLAUDE.md](CLAUDE.md) under a new \"Speeding up `uv sync` rebuilds\" subsection.

## Why

`uv sync` runs the build backend in a fresh tempdir each time, so CMake re-fetches and re-builds ITK from scratch. WARPKIT_DEV worked around that by routing the import through a long-lived `cmake -B build` directory — but it required users to remember to set the env var, and the fallback path made `__init__.py` carry two import strategies.

Setting these once in your shell:

```sh
export FETCHCONTENT_BASE_DIR=$HOME/.cache/warpkit-fetchcontent
export CMAKE_CXX_COMPILER_LAUNCHER=ccache
```

— gets the same speed-up. ITK's tarball gets fetched + extracted once total; ccache hits on rebuilds of the same ITK sources in a fresh build dir. CMake still re-configures per sync (PEP-517 doesn't expose a persistent build dir), but the heavy work is amortized.

`WARPKIT_DEV` wasn't documented anywhere outside the code, so removal is a clean op.

## Test plan

- [x] `uv sync --group dev --config-setting editable_mode=strict` builds successfully without `WARPKIT_DEV`
- [ ] Verify `FETCHCONTENT_BASE_DIR` survives across syncs (manual: `ls ~/.cache/warpkit-fetchcontent` populated after first sync)
- [ ] Verify ccache hits on second sync (`ccache -s` shows non-zero hits after second sync)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)