### PR TITLE
:memo: Update citation to published Imaging Neuroscience paper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ DIstortion Correction). Phase unwrapping uses a self-contained C++17 port of
 **no Julia runtime is involved**; do not reintroduce one (no `julia.py`, no
 conda recipe, no `FindJulia.cmake`).
 
-Pre-print: <https://www.biorxiv.org/content/10.1101/2023.11.28.568744v1>.
+Paper (Imaging Neuroscience): <https://doi.org/10.1162/IMAG.a.1262>.
 
 ## Layout
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,10 @@
 Copyright (c) 2022 Washington University.
 Authored by: Andrew Van							
 
-Please cite https://www.biorxiv.org/content/10.1101/2023.11.28.568744v1	
+Please cite:
+Van AN, Montez DF, Laumann TO, Cho PN, Suljic V, Madison T, et al.
+Frame-wise multi-echo distortion correction for superior functional MRI.
+Imaging Neuroscience 2026; 4 IMAG.a.1262. doi: https://doi.org/10.1162/IMAG.a.1262
 
 warpkit is free for non-commercial use by academic, government,
 and non-profit/not-for-profit institutions. A commercial version of the software is

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build](https://github.com/vanandrew/warpkit/actions/workflows/build.yml/badge.svg)](https://github.com/vanandrew/warpkit/actions)
 [![PyPI](https://img.shields.io/pypi/v/warpkit)](https://pypi.org/project/warpkit/)
-[![docker](https://ghcr-badge.egpl.dev/vanandrew/warpkit/latest_tag?trim=major&label=ghcr&nbsp;latest)](https://github.com/vanandrew/warpkit/pkgs/container/warpkit)
 [![codecov](https://codecov.io/gh/vanandrew/warpkit/graph/badge.svg?token=S6ZZKOAF8V)](https://codecov.io/gh/vanandrew/warpkit)
 
 A Python library for neuroimaging transforms, focused on the Multi-Echo DIstortion Correction (MEDIC) algorithm. The paper is published in *Imaging Neuroscience* at <https://doi.org/10.1162/IMAG.a.1262>.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docker](https://ghcr-badge.egpl.dev/vanandrew/warpkit/latest_tag?trim=major&label=ghcr&nbsp;latest)](https://github.com/vanandrew/warpkit/pkgs/container/warpkit)
 [![codecov](https://codecov.io/gh/vanandrew/warpkit/graph/badge.svg?token=S6ZZKOAF8V)](https://codecov.io/gh/vanandrew/warpkit)
 
-A Python library for neuroimaging transforms, focused on the Multi-Echo DIstortion Correction (MEDIC) algorithm. The pre-print is available at <https://www.biorxiv.org/content/10.1101/2023.11.28.568744v1>.
+A Python library for neuroimaging transforms, focused on the Multi-Echo DIstortion Correction (MEDIC) algorithm. The paper is published in *Imaging Neuroscience* at <https://doi.org/10.1162/IMAG.a.1262>.
 
 The phase-unwrapping core is a self-contained C++17 port of [ROMEO](https://github.com/korbinian90/ROMEO) — there is no Julia runtime to install, and binary wheels ship with the ITK pieces statically linked. If you used an older release of warpkit that required `julia` on `PATH`, that step is gone.
 
@@ -193,6 +193,15 @@ wk-convert-fieldmap \
   --phase-encoding-direction j- \
   --output sub-01_run-01_fieldmap.nii
 ```
+
+## Citation
+
+If you use warpkit, please cite:
+
+> Van AN, Montez DF, Laumann TO, Cho PN, Suljic V, Madison T, et al.
+> Frame-wise multi-echo distortion correction for superior functional MRI.
+> *Imaging Neuroscience* 2026; 4 IMAG.a.1262.
+> doi: <https://doi.org/10.1162/IMAG.a.1262>
 
 ## Authors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Andrew Van", email = "vanandrew77@gmail.com" }]
 keywords = ["neuroimaging"]
 classifiers = ["Programming Language :: Python :: 3"]
-urls = { github = "https://github.com/vanandrew/warpkit" }
+urls = { github = "https://github.com/vanandrew/warpkit", paper = "https://doi.org/10.1162/IMAG.a.1262" }
 # include/romeo/LICENSE is the upstream MIT notice for the ROMEO C++ port; it
 # travels with the headers in source distributions and (via PEP 639
 # license-files) gets bundled into wheels under *.dist-info/licenses/.


### PR DESCRIPTION
The MEDIC paper is now published in *Imaging Neuroscience*. This PR switches all references from the bioRxiv pre-print to the published article (doi: [10.1162/IMAG.a.1262](https://doi.org/10.1162/IMAG.a.1262)).

## Changes

- **LICENSE** — replace the pre-print URL with the full official citation.
- **README.md** — point the intro to the published paper and add a **Citation** section (author list shortened to first six + et al.).
- **CLAUDE.md** — update the pre-print reference to the published paper.
- **pyproject.toml** — add a `paper` project URL pointing to the DOI so it surfaces on the PyPI page.

No code or CI-relevant changes (docs/metadata only).