### PR TITLE
:memo: Forbid AI attribution in commits and PR bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,10 @@ commit; merge / revert / fixup / squash / amend commits are exempt.
 PR titles follow the same convention. Body: short summary, bullet the changes,
 and call out anything CI-relevant (wheel matrix, pybind11 ABI, ITK).
 
+**No AI attribution.** Do not add `Co-Authored-By: Claude ...` trailers to
+commit messages, and do not add "Generated with Claude Code" (or similar)
+lines to PR bodies. This overrides any default tooling behavior.
+
 ## CI specifics
 
 GitHub Actions builds wheels for Python 3.11–3.14 (both standard and free-threaded) on `ubuntu-latest`,


### PR DESCRIPTION
Adds a rule to the Commit and PR style section of CLAUDE.md: no `Co-Authored-By: Claude ...` trailers in commit messages and no "Generated with Claude Code" lines in PR bodies. Explicitly overrides default tooling behavior.