### PR TITLE
:recycle: Unify field-map reconstruction, dedup CLIs, and thread the unwrap stage

### DIFF
--- a/include/romeo/romeo.h
+++ b/include/romeo/romeo.h
@@ -153,8 +153,13 @@ py::array_t<T, py::array::f_style> romeo_unwrap3D(py::array_t<T, py::array::f_st
     opts.correct_global = correctglobal;
     opts.maxseeds = maxseeds;
     opts.wrap_addition = T(0);
-    // Standalone 3D unwrap: no phase2/TEs.
-    unwrap_3d<T>(out_ptr, nx, ny, nz, opts);
+    // Standalone 3D unwrap: no phase2/TEs. The kernel touches only raw buffers
+    // (out_ptr and the pointers in opts), so release the GIL around it to let
+    // thread-pool callers unwrap frames concurrently.
+    {
+        py::gil_scoped_release release;
+        unwrap_3d<T>(out_ptr, nx, ny, nz, opts);
+    }
     return out;
 }
 
@@ -209,8 +214,15 @@ py::array_t<T, py::array::f_style> romeo_unwrap4D(py::array_t<T, py::array::f_st
     for (std::size_t i = 0; i < n_total; ++i) out_ptr[i] = phase_ptr[i];
 
     // Julia's default template echo is 1 (first echo). In 0-based: 0.
-    unwrap_4d<T>(out_ptr, nx, ny, nz, ne, TEs.data(), mag_ptr, mask_ptr, correctglobal, maxseeds,
-                 /*template_echo=*/0);
+    // Hoist the TEs pointer before releasing the GIL (.data() must run with the
+    // GIL held); the kernel then works purely on raw buffers, so release the
+    // GIL around it for concurrent thread-pool unwrapping.
+    const T* tes_ptr = TEs.data();
+    {
+        py::gil_scoped_release release;
+        unwrap_4d<T>(out_ptr, nx, ny, nz, ne, tes_ptr, mag_ptr, mask_ptr, correctglobal, maxseeds,
+                     /*template_echo=*/0);
+    }
     return out;
 }
 

--- a/include/warps.h
+++ b/include/warps.h
@@ -19,17 +19,12 @@
 
 namespace py = pybind11;
 
-// PyErr_CheckSignals() needs the GIL; free-threaded builds (Py_GIL_DISABLED)
-// declare `py::mod_gil_not_used()` and skip the check, trading Ctrl+C
-// interruptibility during long ITK operations for no-GIL execution.
-#ifdef Py_GIL_DISABLED
+// Signal checking is intentionally a no-op on all builds. PyErr_CheckSignals()
+// requires holding the GIL, which would block releasing it around the compute
+// kernels (see py::gil_scoped_release in the bindings). We trade in-call Ctrl+C
+// interruptibility for GIL-free execution; SIGINT is still handled between the
+// per-frame C++ calls dispatched from Python.
 #define WARPKIT_CHECK_SIGNALS() ((void)0)
-#else
-#define WARPKIT_CHECK_SIGNALS()                                  \
-    do {                                                         \
-        if (PyErr_CheckSignals() != 0) throw py::error_already_set(); \
-    } while (0)
-#endif
 
 /**
  * @brief Invert a displacement map

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from warpkit.utilities import (
     invert_displacement_field,
     invert_displacement_maps,
     normalize,
+    reconstruct_displacement_and_field_maps,
     rescale_phase,
     setup_logging,
 )
@@ -424,6 +425,15 @@ def test_field_maps_to_displacement_maps_known_value(pe_dir, expected_sign):
     dmap = field_maps_to_displacement_maps(fmap, trt, pe_dir)
     expected = fmap_value * trt * voxel * expected_sign
     assert_allclose(dmap.get_fdata(), expected, atol=1e-5)
+
+
+def test_reconstruct_displacement_and_field_maps_rejects_3d():
+    """The reconstruction tail iterates the trailing axis as frames, so a 3D
+    field map must be rejected up front rather than silently treated as a
+    stack of 2D slices."""
+    fmap_3d = nib.Nifti1Image(np.zeros((4, 4, 4), dtype=np.float32), np.eye(4))
+    with pytest.raises(ValueError, match="must be 4D"):
+        reconstruct_displacement_and_field_maps(fmap_3d, 0.05, "j")
 
 
 @pytest.mark.parametrize("axis", ["i", "j", "k"])

--- a/warpkit/distortion.py
+++ b/warpkit/distortion.py
@@ -4,11 +4,7 @@ import nibabel as nib
 import numpy as np
 
 from warpkit.unwrap import unwrap_and_compute_field_maps
-from warpkit.utilities import (
-    displacement_maps_to_field_maps,
-    field_maps_to_displacement_maps,
-    invert_displacement_maps,
-)
+from warpkit.utilities import reconstruct_displacement_and_field_maps
 
 
 def medic(
@@ -119,36 +115,10 @@ def medic(
             ":("
         ) from e
 
-    # convert to displacement maps (these are in distorted space)
-    inv_displacement_maps = field_maps_to_displacement_maps(
+    # reconstruct displacement maps and undistorted-space field maps
+    displacement_maps, field_maps = reconstruct_displacement_and_field_maps(
         field_maps_native, total_readout_time, phase_encoding_direction
     )
-
-    # invert displacement maps (these are in undistorted space)
-    displacement_maps = invert_displacement_maps(
-        inv_displacement_maps, phase_encoding_direction, ignore_rotation=True
-    )
-
-    # convert correction maps back to undistorted space field map. No
-    # flip_sign here: the correlation check below sets the sign relative to
-    # the native field map, which makes an up-front flip redundant.
-    field_maps = displacement_maps_to_field_maps(
-        displacement_maps, total_readout_time, phase_encoding_direction
-    )
-
-    # check if we need to flip sign of field maps (this is done by comparing sign of correlation between
-    # native and undistorted field maps)
-    if (
-        np.corrcoef(
-            field_maps.dataobj[..., 0].ravel(),
-            field_maps_native.dataobj[..., 0].ravel(),
-        )[0, 1]
-        < 0
-    ):
-        field_map_data = field_maps.get_fdata() * -1
-        field_maps = nib.Nifti1Image(
-            field_map_data, field_maps.affine, field_maps.header
-        )
 
     # return correction maps
     return field_maps_native, displacement_maps, field_maps

--- a/warpkit/scripts/_cli.py
+++ b/warpkit/scripts/_cli.py
@@ -1,0 +1,51 @@
+"""Shared argparse argument builders for the warpkit CLI scripts.
+
+These cover the argument blocks that are byte-identical across multiple
+scripts (``--version``, ``-n/--n-cpus``, and the EPI ``--total-readout-time`` /
+``--phase-encoding-direction`` pair). Args whose help text is worded per
+script (``--magnitude``, ``--metadata``, ``--debug``, ...) stay inline in each
+script so their wording can diverge freely.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from warpkit import __version__
+from warpkit.utilities import PE_DIRECTIONS
+
+
+def add_version_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the standard ``--version`` action."""
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+
+
+def add_n_cpus_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the standard ``-n/--n-cpus`` option (default 4)."""
+    parser.add_argument(
+        "-n", "--n-cpus", type=int, default=4, help="Number of CPUs to use."
+    )
+
+
+def add_trt_pe_args(parser: argparse.ArgumentParser) -> None:
+    """Add ``--total-readout-time`` and ``--phase-encoding-direction``.
+
+    Used by the pipeline scripts where both are optional (resolved from
+    ``--metadata`` when omitted).
+    """
+    parser.add_argument(
+        "--total-readout-time",
+        type=float,
+        help="Total readout time in seconds. Required unless --metadata is given.",
+    )
+    parser.add_argument(
+        "--phase-encoding-direction",
+        choices=PE_DIRECTIONS,
+        metavar="DIR",
+        help=(
+            f"Phase encoding direction (one of: {', '.join(PE_DIRECTIONS)}). "
+            "Required unless --metadata is given."
+        ),
+    )

--- a/warpkit/scripts/_outputs.py
+++ b/warpkit/scripts/_outputs.py
@@ -1,0 +1,54 @@
+"""Shared output handling for the MEDIC field-map scripts.
+
+``wk-medic`` and ``wk-compute-fieldmap`` write the same three NIfTIs from a
+prefix — native-space field map, displacement maps, undistorted-space field
+map — and return the same triple of resolved paths. This module hosts the
+result type and the writer they share.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+
+import nibabel as nib
+
+
+@dataclass(frozen=True, slots=True)
+class MedicResult:
+    """Absolute paths of the three NIfTIs written by the MEDIC field-map
+    scripts: native-space field map, displacement maps, and undistorted-space
+    field map."""
+
+    fieldmap_native: Path
+    displacement_map: Path
+    fieldmap: Path
+
+
+def write_medic_outputs(
+    out_prefix: PathLike[str] | str,
+    fieldmap_native: nib.Nifti1Image,
+    displacement_map: nib.Nifti1Image,
+    fieldmap: nib.Nifti1Image,
+) -> MedicResult:
+    """Write the three MEDIC NIfTIs under ``out_prefix`` and return their
+    resolved paths.
+
+    Writes ``<prefix>_fieldmaps_native.nii``, ``<prefix>_displacementmaps.nii``
+    and ``<prefix>_fieldmaps.nii``.
+    """
+    out_prefix_str = str(out_prefix)
+    print("Saving field maps and displacement maps to file...")
+    fmap_native_path = Path(f"{out_prefix_str}_fieldmaps_native.nii").resolve()
+    dmap_path = Path(f"{out_prefix_str}_displacementmaps.nii").resolve()
+    fmap_path = Path(f"{out_prefix_str}_fieldmaps.nii").resolve()
+    fieldmap_native.to_filename(str(fmap_native_path))
+    displacement_map.to_filename(str(dmap_path))
+    fieldmap.to_filename(str(fmap_path))
+    print("Done.")
+    return MedicResult(
+        fieldmap_native=fmap_native_path,
+        displacement_map=dmap_path,
+        fieldmap=fmap_path,
+    )

--- a/warpkit/scripts/apply_warp.py
+++ b/warpkit/scripts/apply_warp.py
@@ -19,7 +19,6 @@ from typing import cast
 import nibabel as nib
 import numpy as np
 
-from warpkit import __version__
 from warpkit.utilities import (
     AXIS_MAP,
     WARP_ITK_FLIPS,
@@ -30,6 +29,7 @@ from warpkit.utilities import (
 )
 
 from . import epilog
+from ._cli import add_version_arg
 from ._metadata import ensure_image, ensure_images
 
 
@@ -243,9 +243,7 @@ def main():
         ),
         epilog=f"{epilog} 04/24/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument(
         "--input",
         required=True,

--- a/warpkit/scripts/compute_fieldmap.py
+++ b/warpkit/scripts/compute_fieldmap.py
@@ -12,35 +12,23 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
-from dataclasses import dataclass
 from os import PathLike
-from pathlib import Path
 
 import nibabel as nib
-import numpy as np
 
-from warpkit import __version__
 from warpkit.unwrap import compute_field_maps
 from warpkit.utilities import (
-    displacement_maps_to_field_maps,
-    field_maps_to_displacement_maps,
-    invert_displacement_maps,
+    reconstruct_displacement_and_field_maps,
     setup_logging,
 )
 
 from . import epilog
+from ._cli import add_n_cpus_arg, add_trt_pe_args, add_version_arg
 from ._metadata import ensure_image, ensure_images, resolve_acquisition
+from ._outputs import MedicResult, write_medic_outputs
 
-PE_DIRECTIONS = ("i", "j", "k", "i-", "j-", "k-", "x", "y", "z", "x-", "y-", "z-")
-
-
-@dataclass(frozen=True, slots=True)
-class ComputeFieldmapResult:
-    """Same three-tuple as :class:`MedicResult`."""
-
-    fieldmap_native: Path
-    displacement_map: Path
-    fieldmap: Path
+# wk-compute-fieldmap writes and returns the same three NIfTIs as wk-medic.
+ComputeFieldmapResult = MedicResult
 
 
 def compute_fieldmap(
@@ -102,34 +90,10 @@ def compute_fieldmap(
 
     # Convert native-space field maps to displacement maps in distorted space,
     # invert to get distorted -> undistorted, then re-derive an undistorted-
-    # space field map. Mirrors warpkit.distortion.medic.
-    inv_displacement_maps = field_maps_to_displacement_maps(fmaps_native, trt, ped)
-    dmaps = invert_displacement_maps(inv_displacement_maps, ped)
-    fmaps = displacement_maps_to_field_maps(dmaps, trt, ped, flip_sign=True)
+    # space field map. Shared with warpkit.distortion.medic.
+    dmaps, fmaps = reconstruct_displacement_and_field_maps(fmaps_native, trt, ped)
 
-    if (
-        np.corrcoef(
-            fmaps.dataobj[..., 0].ravel(),
-            fmaps_native.dataobj[..., 0].ravel(),
-        )[0, 1]
-        < 0
-    ):
-        fmaps = nib.Nifti1Image(fmaps.get_fdata() * -1, fmaps.affine, fmaps.header)
-
-    out_prefix_str = str(out_prefix)
-    print("Saving field maps and displacement maps to file...")
-    fmap_native_path = Path(f"{out_prefix_str}_fieldmaps_native.nii").resolve()
-    dmap_path = Path(f"{out_prefix_str}_displacementmaps.nii").resolve()
-    fmap_path = Path(f"{out_prefix_str}_fieldmaps.nii").resolve()
-    fmaps_native.to_filename(str(fmap_native_path))
-    dmaps.to_filename(str(dmap_path))
-    fmaps.to_filename(str(fmap_path))
-    print("Done.")
-    return ComputeFieldmapResult(
-        fieldmap_native=fmap_native_path,
-        displacement_map=dmap_path,
-        fieldmap=fmap_path,
-    )
+    return write_medic_outputs(out_prefix, fmaps_native, dmaps, fmaps)
 
 
 def main():
@@ -144,9 +108,7 @@ def main():
         ),
         epilog=f"{epilog} 04/24/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument(
         "--magnitude",
         nargs="+",
@@ -184,20 +146,7 @@ def main():
             "--unwrapped order). Required unless --metadata is given."
         ),
     )
-    parser.add_argument(
-        "--total-readout-time",
-        type=float,
-        help="Total readout time in seconds. Required unless --metadata is given.",
-    )
-    parser.add_argument(
-        "--phase-encoding-direction",
-        choices=PE_DIRECTIONS,
-        metavar="DIR",
-        help=(
-            f"Phase encoding direction (one of: {', '.join(PE_DIRECTIONS)}). "
-            "Required unless --metadata is given."
-        ),
-    )
+    add_trt_pe_args(parser)
     parser.add_argument(
         "--out-prefix",
         required=True,
@@ -217,9 +166,7 @@ def main():
         default=10,
         help="SVD components for global denoising (default: 10).",
     )
-    parser.add_argument(
-        "-n", "--n-cpus", type=int, default=4, help="Number of CPUs to use."
-    )
+    add_n_cpus_arg(parser)
 
     args = parser.parse_args()
     setup_logging()

--- a/warpkit/scripts/compute_jacobian.py
+++ b/warpkit/scripts/compute_jacobian.py
@@ -18,7 +18,6 @@ from typing import cast
 
 import nibabel as nib
 
-from warpkit import __version__
 from warpkit.utilities import (
     AXIS_MAP,
     WARP_ITK_FLIPS,
@@ -29,6 +28,7 @@ from warpkit.utilities import (
 )
 
 from . import epilog
+from ._cli import add_version_arg
 from ._warp_io import read_input_frames, write_output
 
 
@@ -119,9 +119,7 @@ def main():
         ),
         epilog=f"{epilog} 04/25/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument(
         "--input",
         nargs="+",

--- a/warpkit/scripts/convert_fieldmap.py
+++ b/warpkit/scripts/convert_fieldmap.py
@@ -17,9 +17,8 @@ from pathlib import Path
 
 import nibabel as nib
 
-from warpkit import __version__
 from warpkit.utilities import (
-    AXIS_MAP,
+    PE_DIRECTIONS,
     WARP_ITK_FLIPS,
     displacement_field_to_map,
     displacement_map_to_field,
@@ -29,9 +28,8 @@ from warpkit.utilities import (
 )
 
 from . import epilog
+from ._cli import add_version_arg
 from ._warp_io import read_input_frames, write_output
-
-PE_DIRECTIONS = tuple(AXIS_MAP)
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,9 +167,7 @@ def main():
         ),
         epilog=f"{epilog} 04/25/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument(
         "--input",
         nargs="+",

--- a/warpkit/scripts/convert_warp.py
+++ b/warpkit/scripts/convert_warp.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import nibabel as nib
 import numpy as np
 
-from warpkit import __version__
 from warpkit.utilities import (
     AXIS_MAP,
     WARP_ITK_FLIPS,
@@ -35,6 +34,7 @@ from warpkit.utilities import (
 )
 
 from . import epilog
+from ._cli import add_version_arg
 from ._warp_io import read_input_frames, write_output
 
 
@@ -227,9 +227,7 @@ def main():
         ),
         epilog=f"{epilog} 04/25/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument(
         "--input",
         nargs="+",

--- a/warpkit/scripts/medic.py
+++ b/warpkit/scripts/medic.py
@@ -18,29 +18,17 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
-from dataclasses import dataclass
 from os import PathLike
-from pathlib import Path
 
 import nibabel as nib
 
-from warpkit import __version__
 from warpkit.distortion import medic as _medic_distortion
 from warpkit.utilities import setup_logging
 
 from . import epilog
+from ._cli import add_n_cpus_arg, add_trt_pe_args, add_version_arg
 from ._metadata import ensure_images, resolve_acquisition, trim_noise_frames
-
-PE_DIRECTIONS = ("i", "j", "k", "i-", "j-", "k-", "x", "y", "z", "x-", "y-", "z-")
-
-
-@dataclass(frozen=True, slots=True)
-class MedicResult:
-    """Absolute paths of the three NIfTIs written by :func:`medic`."""
-
-    fieldmap_native: Path
-    displacement_map: Path
-    fieldmap: Path
+from ._outputs import MedicResult, write_medic_outputs
 
 
 def medic(
@@ -126,29 +114,14 @@ def medic(
             wrap_limit=wrap_limit,
         )
 
-    out_prefix_str = str(out_prefix)
-    print("Saving field maps and displacement maps to file...")
-    fmap_native_path = Path(f"{out_prefix_str}_fieldmaps_native.nii").resolve()
-    dmap_path = Path(f"{out_prefix_str}_displacementmaps.nii").resolve()
-    fmap_path = Path(f"{out_prefix_str}_fieldmaps.nii").resolve()
-    fmaps_native.to_filename(str(fmap_native_path))
-    dmaps.to_filename(str(dmap_path))
-    fmaps.to_filename(str(fmap_path))
-    print("Done.")
-    return MedicResult(
-        fieldmap_native=fmap_native_path,
-        displacement_map=dmap_path,
-        fieldmap=fmap_path,
-    )
+    return write_medic_outputs(out_prefix, fmaps_native, dmaps, fmaps)
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Multi-Echo DIstortion Correction", epilog=f"{epilog}"
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument("--magnitude", nargs="+", required=True, help="Magnitude data")
     parser.add_argument("--phase", nargs="+", required=True, help="Phase data")
     parser.add_argument(
@@ -171,20 +144,7 @@ def main():
             "Required unless --metadata is given."
         ),
     )
-    parser.add_argument(
-        "--total-readout-time",
-        type=float,
-        help="Total readout time in seconds. Required unless --metadata is given.",
-    )
-    parser.add_argument(
-        "--phase-encoding-direction",
-        choices=PE_DIRECTIONS,
-        metavar="DIR",
-        help=(
-            f"Phase encoding direction (one of: {', '.join(PE_DIRECTIONS)}). "
-            "Required unless --metadata is given."
-        ),
-    )
+    add_trt_pe_args(parser)
     parser.add_argument(
         "--out-prefix",
         required=True,
@@ -193,9 +153,7 @@ def main():
     parser.add_argument(
         "-f", "--noiseframes", type=int, default=0, help="Number of noise frames"
     )
-    parser.add_argument(
-        "-n", "--n-cpus", type=int, default=4, help="Number of CPUs to use."
-    )
+    add_n_cpus_arg(parser)
     parser.add_argument("--debug", action="store_true", help="Debug mode")
     parser.add_argument(
         "--wrap-limit",

--- a/warpkit/scripts/unwrap_phase.py
+++ b/warpkit/scripts/unwrap_phase.py
@@ -19,11 +19,11 @@ from pathlib import Path
 
 import nibabel as nib
 
-from warpkit import __version__
 from warpkit.unwrap import unwrap_phases
 from warpkit.utilities import setup_logging
 
 from . import epilog
+from ._cli import add_n_cpus_arg, add_version_arg
 from ._metadata import ensure_images, resolve_acquisition, trim_noise_frames
 
 
@@ -113,9 +113,7 @@ def main():
         ),
         epilog=f"{epilog} 04/24/2026",
     )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    add_version_arg(parser)
     parser.add_argument("--magnitude", nargs="+", required=True, help="Magnitude data")
     parser.add_argument("--phase", nargs="+", required=True, help="Phase data")
     parser.add_argument(
@@ -144,9 +142,7 @@ def main():
     parser.add_argument(
         "-f", "--noiseframes", type=int, default=0, help="Number of noise frames"
     )
-    parser.add_argument(
-        "-n", "--n-cpus", type=int, default=4, help="Number of CPUs to use."
-    )
+    add_n_cpus_arg(parser)
     parser.add_argument(
         "--debug",
         action="store_true",

--- a/warpkit/unwrap.py
+++ b/warpkit/unwrap.py
@@ -820,10 +820,12 @@ def unwrap_phases(
         # store in the captured unwrapped and new_mask_data arrays
         unwrapped[..., idx], new_masks[..., idx] = result
 
-    # unwrap the phase of each frame
+    # unwrap the phase of each frame. romeo_unwrap* releases the GIL around the
+    # C++ kernel, so threads parallelize it as well as processes while avoiding
+    # per-frame array pickling and per-worker memory copies.
     run_executor(
         ncpus=n_cpus,
-        type="process",
+        type="thread",
         fn=unwrap_phase,
         iterator=phase_iterator(
             phase, mag, tes, mask, frames, automask, automask_dilation

--- a/warpkit/utilities.py
+++ b/warpkit/utilities.py
@@ -44,6 +44,10 @@ AXIS_MAP = {
     "k-": 2,
 }
 
+# accepted phase-encoding direction strings (the keys of AXIS_MAP), shared by
+# the field-map conversions and the CLI ``choices=`` lists.
+PE_DIRECTIONS = tuple(AXIS_MAP)
+
 
 # warp_itk_flips
 WARP_ITK_FLIPS = {
@@ -242,6 +246,23 @@ def create_brain_mask(
     return mask_data.astype(np.bool_)
 
 
+def _signed_pe_voxel_size(img: nib.Nifti1Image, phase_encoding_direction: str) -> float:
+    """Voxel size (mm) along the phase-encoding axis, signed for the EPI
+    displacement <-> field-map conversions.
+
+    The sign carries two conventions: a trailing ``-`` in the phase-encoding
+    direction flips the displacement direction, and the x/y axes are flipped
+    for the ITK (LPS) frame relative to NIfTI RAS.
+    """
+    axis_code = AXIS_MAP[phase_encoding_direction]
+    voxel_size = img.header.get_zooms()[axis_code]  # type: ignore
+    if "-" in phase_encoding_direction:
+        voxel_size *= -1
+    if axis_code == 0 or axis_code == 1:
+        voxel_size *= -1
+    return voxel_size
+
+
 def field_maps_to_displacement_maps(
     field_maps: nib.Nifti1Image,
     total_readout_time: float,
@@ -263,20 +284,7 @@ def field_maps_to_displacement_maps(
     nib.Nifti1Image
         Displacment maps in mm
     """
-    # get number of phase encoding lines
-    axis_code = AXIS_MAP[phase_encoding_direction]
-
-    # get voxel size
-    voxel_size = field_maps.header.get_zooms()[axis_code]  # type: ignore
-
-    # if there is a negative sign in the phase encoding direction
-    # we need to flip the direction of the displacment map
-    if "-" in phase_encoding_direction:
-        voxel_size *= -1
-
-    # for itk form, we need to flip x/y axis
-    if axis_code == 0 or axis_code == 1:
-        voxel_size *= -1
+    voxel_size = _signed_pe_voxel_size(field_maps, phase_encoding_direction)
 
     # convert field maps to displacement maps
     data = field_maps.get_fdata()
@@ -311,20 +319,7 @@ def displacement_maps_to_field_maps(
     nib.Nifti1Image
         Field maps in Hz
     """
-    # get number of phase encoding lines
-    axis_code = AXIS_MAP[phase_encoding_direction]
-
-    # get voxel size
-    voxel_size = displacement_maps.header.get_zooms()[axis_code]  # type: ignore
-
-    # if there is a negative sign in the phase encoding direction
-    # we need to flip the direction of the displacment map
-    if "-" in phase_encoding_direction:
-        voxel_size *= -1
-
-    # for itk form, we need to flip x/y axis
-    if axis_code == 0 or axis_code == 1:
-        voxel_size *= -1
+    voxel_size = _signed_pe_voxel_size(displacement_maps, phase_encoding_direction)
 
     # convert displacement maps to field maps
     data = displacement_maps.get_fdata()
@@ -333,6 +328,72 @@ def displacement_maps_to_field_maps(
         new_data *= -1
 
     return nib.Nifti1Image(new_data, displacement_maps.affine, displacement_maps.header)
+
+
+def reconstruct_displacement_and_field_maps(
+    field_maps_native: nib.Nifti1Image,
+    total_readout_time: float,
+    phase_encoding_direction: str,
+) -> tuple[nib.Nifti1Image, nib.Nifti1Image]:
+    """Reconstruct correction maps from a native-space field map.
+
+    Converts native-space field maps (Hz) to displacement maps in distorted
+    space, inverts them to get distorted -> undistorted correction maps, and
+    re-derives an undistorted-space field map. This is the shared reconstruction
+    tail used by both :func:`warpkit.distortion.medic` and
+    :func:`warpkit.scripts.compute_fieldmap.compute_fieldmap`.
+
+    Parameters
+    ----------
+    field_maps_native : nib.Nifti1Image
+        Field maps in Hz (distorted/native space).
+    total_readout_time : float
+        Total readout time (in seconds).
+    phase_encoding_direction : str
+        Phase encoding direction.
+
+    Returns
+    -------
+    nib.Nifti1Image
+        Displacement maps (distorted -> undistorted) in mm.
+    nib.Nifti1Image
+        Field maps in Hz (undistorted space).
+    """
+    # convert to displacement maps (these are in distorted space)
+    inv_displacement_maps = field_maps_to_displacement_maps(
+        field_maps_native, total_readout_time, phase_encoding_direction
+    )
+
+    # invert displacement maps (these are in undistorted space). The maps are
+    # composed along the phase-encode voxel axis, so invert in the voxel grid
+    # frame (ignore_rotation=True) rather than the affine's physical frame —
+    # otherwise oblique acquisitions pick up an obliquity-dependent error.
+    displacement_maps = invert_displacement_maps(
+        inv_displacement_maps, phase_encoding_direction, ignore_rotation=True
+    )
+
+    # convert correction maps back to undistorted-space field map. No flip_sign
+    # here: the correlation check below sets the sign relative to the native
+    # field map, which makes an up-front flip redundant.
+    field_maps = displacement_maps_to_field_maps(
+        displacement_maps, total_readout_time, phase_encoding_direction
+    )
+
+    # flip sign of the field maps if needed, determined by the sign of the
+    # correlation between the native and undistorted field maps.
+    if (
+        np.corrcoef(
+            field_maps.dataobj[..., 0].ravel(),
+            field_maps_native.dataobj[..., 0].ravel(),
+        )[0, 1]
+        < 0
+    ):
+        field_map_data = field_maps.get_fdata() * -1
+        field_maps = nib.Nifti1Image(
+            field_map_data, field_maps.affine, field_maps.header
+        )
+
+    return displacement_maps, field_maps
 
 
 def displacement_map_to_field(

--- a/warpkit/utilities.py
+++ b/warpkit/utilities.py
@@ -359,6 +359,15 @@ def reconstruct_displacement_and_field_maps(
     nib.Nifti1Image
         Field maps in Hz (undistorted space).
     """
+    # Require a 4D (x, y, z, frame) series: invert_displacement_maps() iterates
+    # over the trailing axis as frames, so a 3D input would be silently treated
+    # as a stack of 2D slices and fed to the C++ inverter as such.
+    if field_maps_native.ndim != 4:
+        raise ValueError(
+            "field_maps_native must be 4D (x, y, z, frames); got "
+            f"{field_maps_native.ndim}D with shape {field_maps_native.shape}."
+        )
+
     # convert to displacement maps (these are in distorted space)
     inv_displacement_maps = field_maps_to_displacement_maps(
         field_maps_native, total_readout_time, phase_encoding_direction


### PR DESCRIPTION
## Summary

Three related changes to the MEDIC field-map path: a shared reconstruction
tail (which also fixes an oblique-acquisition bug in `wk-compute-fieldmap`),
deduplication of CLI/output scaffolding, and releasing the GIL in the ROMEO
unwrap so the whole pipeline can run on threads.

## Changes

### 1. Unify field-map reconstruction (`:recycle:` + bug fix)
- Add `utilities.reconstruct_displacement_and_field_maps()` as the single
  source of truth for the convert → invert → reconvert → sign-check pipeline.
  `warpkit.distortion.medic` and `wk-compute-fieldmap` both call it.
- **Fix:** `wk-compute-fieldmap` now inverts displacement in data (voxel) space
  (`ignore_rotation=True`) like `medic()`, correcting an obliquity-dependent
  error on oblique acquisitions, and drops the redundant `flip_sign=True` (the
  correlation check is the sole sign authority).
- Add `_signed_pe_voxel_size()` shared by the two field-map converters.
- Define `PE_DIRECTIONS` once (`tuple(AXIS_MAP)`) in utilities; drop the two
  hand-written literals.

### 2. Dedup CLI/output scaffolding
- `scripts/_outputs.py`: one `MedicResult` dataclass + `write_medic_outputs()`
  shared by `wk-medic` and `wk-compute-fieldmap` (`ComputeFieldmapResult` kept
  as a back-compat alias).
- `scripts/_cli.py`: `add_version_arg` / `add_n_cpus_arg` / `add_trt_pe_args`
  for the byte-identical argparse blocks; rewire all seven CLIs.

### 3. Release the GIL in ROMEO unwrap; thread the unwrap stage (`:zap:`)
- Wrap the `unwrap_3d`/`unwrap_4d` kernels in `py::gil_scoped_release` (output
  allocated and numpy pointers grabbed with the GIL held first; kernel runs on
  raw buffers only).
- Switch the unwrap executor from processes to threads. With the GIL released,
  threads parallelize unwrap as well as processes (205-frame run, 8 cpus:
  thread 4.35s vs process 4.59s; was 6.65s vs 4.74s) without per-frame array
  pickling or per-worker memory copies. The field-map and temporal-consistency
  stages already used threads.
- Make `WARPKIT_CHECK_SIGNALS()` an unconditional no-op (drops in-call Ctrl+C;
  SIGINT is still handled between per-frame calls).

## Testing
- All 212 tests pass; `ruff` + `pyright` clean.
- Concurrency stress: 8 workers × 24 frames × 5 reps of genuinely concurrent
  unwrap is bit-identical to serial (`max|Δ| = 0`) — no data races.
- Benchmarked on the 205-frame `ds006926 sub-a01 VisMot tr1800` run.

## CI-relevant notes
- Touches the pybind11 bindings (GIL handling) but no binding **signatures**
  change, so the `.pyi` stub is unchanged.
- The unwrap stage no longer spawns processes — removes fork/spawn platform
  divergence. The GIL release also benefits the free-threaded wheels.