### PR TITLE
:bug: Correct EPI distortion direction for non-RAS orientations

### DIFF
--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -248,7 +248,8 @@ def test_resample_integer_voxel_shift_ras(pe_dir, expected_shift):
     col_in = ramp[6, interior, 8]
     col_out = out[6, interior, 8]
     assert_allclose(col_out - col_in, expected_shift, atol=1e-4)
-    # the off-axis planes are unchanged (no x/z displacement)
-    assert_allclose(
-        out[6, interior, 8], ramp[6, interior, 8] + expected_shift, atol=1e-4
-    )
+    # there really is no x/z displacement — assert it on the field directly,
+    # since the ramp is flat in x/z and can't reveal off-axis motion via resample.
+    field_data = field.get_fdata()
+    assert_allclose(field_data[..., AXIS_MAP["x"]], 0.0, atol=1e-6)
+    assert_allclose(field_data[..., AXIS_MAP["z"]], 0.0, atol=1e-6)

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,254 @@
+"""Orientation x phase-encoding-direction correctness.
+
+MEDIC (and the correction it produces) is a physical operation: the same field
+map, phase-encode direction, and image must yield the *same physical* correction
+no matter which of the 48 valid voxel orientations the data happens to be stored
+in on disk — provided the phase-encoding-direction (PED) string is relabelled to
+match each storage orientation, exactly as BIDS requires.
+
+The suite therefore takes RAS as the golden reference (the orientation warpkit
+was validated against) and asserts that every other orientation reduces to the
+*same* physical result. Because RAS is correct, this equivariance is equivalent
+to correctness for every orientation.
+
+Two absolute anchors in RAS pin the sign/magnitude so the sweep can't pass by
+being uniformly wrong, and an oracle-guard test independently checks that the
+PED-remap helper the sweep relies on really does track the intended physical
+axis.
+
+See ``tests/test_utilities.py`` for the per-function (Hz<->mm, map<->field)
+convention tests; this file is the end-to-end orientation behaviour.
+"""
+
+import itertools
+from collections.abc import Sequence
+from typing import cast
+
+import nibabel as nib
+import numpy as np
+import pytest
+from nibabel.orientations import axcodes2ornt, io_orientation, ornt_transform
+from numpy.testing import assert_allclose
+from warpkit.utilities import (
+    AXIS_MAP,
+    displacement_map_to_field,
+    field_maps_to_displacement_maps,
+    reconstruct_displacement_and_field_maps,
+    resample_image,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+# The three anatomical axis pairs (positive, negative endpoint per world axis).
+_AXIS_PAIRS = (("R", "L"), ("A", "P"), ("S", "I"))
+
+
+def _all_axcodes() -> list[tuple[str, str, str]]:
+    """Every valid voxel orientation: the 6 axis permutations x 8 sign
+    combinations = 48 axcode triples (RAS, LAS, PSR, ...)."""
+    codes = []
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((0, 1), repeat=3):
+            codes.append(tuple(_AXIS_PAIRS[perm[d]][signs[d]] for d in range(3)))
+    return codes
+
+
+ALL_AXCODES = _all_axcodes()
+
+# base phase-encode directions in RAS, keyed by the world axis they point along
+# (+R = world 0, +A = world 1, +S = world 2).
+_BASE_PEDS = {0: "i", 1: "j", 2: "k"}
+
+
+def _reorient(img: nib.Nifti1Image, axcodes: tuple[str, str, str]) -> nib.Nifti1Image:
+    """Relabel ``img`` into the target voxel orientation (lossless: physical
+    content unchanged, only the array layout + affine)."""
+    transform = ornt_transform(io_orientation(img.affine), axcodes2ornt(axcodes))
+    # ornt_transform returns an ndarray; as_reoriented is typed for the nested
+    # Sequence form nibabel also accepts.
+    return img.as_reoriented(cast(Sequence[Sequence[int]], transform))
+
+
+def _ped_for_axcodes(axcodes: tuple[str, str, str], base_world_axis: int) -> str:
+    """The PED string that, in ``axcodes`` storage, points along the same
+    physical direction as the positive ``base_world_axis`` does in RAS.
+
+    ``axcodes2ornt(axcodes)[q] = (w, s)`` means voxel axis q maps to world axis
+    w with sign s; we want the voxel axis carrying ``base_world_axis``, and a
+    trailing ``-`` when increasing that index runs *against* the world axis.
+    """
+    ornt = axcodes2ornt(axcodes)
+    for voxel_axis in range(3):
+        world_axis, sign = ornt[voxel_axis]
+        if int(world_axis) == base_world_axis:
+            letter = "ijk"[voxel_axis]
+            return letter if sign > 0 else letter + "-"
+    raise AssertionError(f"no voxel axis maps to world axis {base_world_axis}")
+
+
+# synthetic acquisition (RAS): anisotropic voxels + a non-trivial origin so the
+# sweep is sensitive to axis-size and translation bookkeeping, an asymmetric
+# smooth field map (Hz), and an off-centre blob to correct.
+_SHAPE = (11, 13, 15)
+_AFFINE = np.diag([2.0, 3.0, 4.0, 1.0])
+_AFFINE[:3, 3] = [5.0, -7.0, 11.0]
+_TRT = 0.04
+
+
+def _ras_inputs() -> tuple[nib.Nifti1Image, nib.Nifti1Image]:
+    ii, jj, kk = np.indices(_SHAPE)
+    fmap = (
+        20.0 * np.sin(2 * np.pi * (ii / _SHAPE[0] + jj / _SHAPE[1] + kk / _SHAPE[2]))
+    ).astype(np.float32)
+    centre = np.array([4.0, 8.0, 6.0])
+    blob = np.exp(
+        -(
+            ((ii - centre[0]) / 3) ** 2
+            + ((jj - centre[1]) / 2.5) ** 2
+            + ((kk - centre[2]) / 3.5) ** 2
+        )
+    ).astype(np.float32)
+    fmap_img = nib.Nifti1Image(fmap[..., None], _AFFINE)  # 4D (single frame)
+    moving_img = nib.Nifti1Image(blob, _AFFINE)
+    return fmap_img, moving_img
+
+
+def _corrected(
+    fmap: nib.Nifti1Image, moving: nib.Nifti1Image, ped: str
+) -> nib.Nifti1Image:
+    """Full correction pipeline: reconstruct the displacement map (with the
+    C++ inversion) then apply it to ``moving`` — exactly what medic + apply-warp
+    do, minus the ROMEO unwrap (which is per-voxel and orientation-agnostic)."""
+    dmaps, _ = reconstruct_displacement_and_field_maps(fmap, _TRT, ped)
+    field = displacement_map_to_field(dmaps, axis=ped, format="itk", frame=0)
+    return resample_image(moving, moving, field)
+
+
+@pytest.fixture(scope="module")
+def ras_references() -> dict[int, np.ndarray]:
+    """The corrected image in RAS for each base PE axis — the golden result
+    every orientation must reproduce."""
+    fmap, moving = _ras_inputs()
+    return {
+        world_axis: _corrected(fmap, moving, ped).get_fdata()
+        for world_axis, ped in _BASE_PEDS.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# oracle guard: the PED-remap helper really tracks the physical axis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axcodes", ALL_AXCODES, ids=lambda a: "".join(a))
+def test_ped_remap_tracks_physical_axis(axcodes):
+    """For every orientation and every physical PE axis, the remapped PED must
+    name the voxel axis whose (signed) direction equals the physical axis — the
+    invariant the equivariance sweep depends on."""
+    affine = _reorient(
+        nib.Nifti1Image(np.zeros(_SHAPE, np.float32), _AFFINE), axcodes
+    ).affine
+    ornt = io_orientation(affine)  # voxel axis -> (world axis, sign)
+    for base_world_axis in (0, 1, 2):
+        ped = _ped_for_axcodes(axcodes, base_world_axis)
+        voxel_axis = AXIS_MAP[ped]
+        world_axis, sign = ornt[voxel_axis]
+        assert int(world_axis) == base_world_axis
+        # a trailing "-" is present iff increasing the voxel index runs against
+        # the positive world direction.
+        expected_negative = sign < 0
+        assert ped.endswith("-") == expected_negative
+
+
+# ---------------------------------------------------------------------------
+# core: orientation equivariance of the full correction over all 48 orientations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axcodes", ALL_AXCODES, ids=lambda a: "".join(a))
+def test_correction_is_orientation_equivariant(axcodes, ras_references):
+    """Reorient the acquisition into ``axcodes``, remap the PED, run the full
+    correction, then reorient the corrected image back to RAS: it must match the
+    RAS reference for every base PE axis, i.e. the physical correction does not
+    depend on how the volume is stored."""
+    fmap_ras, moving_ras = _ras_inputs()
+    fmap = _reorient(fmap_ras, axcodes)
+    moving = _reorient(moving_ras, axcodes)
+
+    for base_world_axis, reference in ras_references.items():
+        ped = _ped_for_axcodes(axcodes, base_world_axis)
+        corrected = _corrected(fmap, moving, ped)
+        # back to RAS for comparison (scalar image -> lossless reorient)
+        back = _reorient(corrected, ("R", "A", "S")).get_fdata()
+        assert_allclose(
+            back,
+            reference,
+            atol=1e-4,
+            err_msg=(
+                f"orientation {''.join(axcodes)} PED {ped!r} (physical axis "
+                f"{base_world_axis}) diverged from the RAS correction"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# absolute anchors in RAS (so the sweep cannot pass by being uniformly wrong)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pe_dir, channel, lps_sign",
+    [
+        ("i", 0, -1.0),  # world x: RAS->LPS flip
+        ("j", 1, -1.0),  # world y: RAS->LPS flip
+        ("k", 2, +1.0),  # world z: no flip
+    ],
+)
+def test_displacement_field_known_value_ras(pe_dir, channel, lps_sign):
+    """A constant field map yields a constant displacement field: magnitude
+    ``fmap * trt * voxel`` in the PE world channel (carrying the RAS->LPS flip),
+    and exactly zero in the other two channels."""
+    voxel = (2.0, 3.0, 4.0)
+    affine = np.diag([*voxel, 1.0])
+    fmap_hz, trt = 10.0, 0.05
+    fmap = nib.Nifti1Image(np.full((5, 5, 5), fmap_hz, np.float32), affine)
+    dmap = field_maps_to_displacement_maps(fmap, trt, pe_dir)
+    field = displacement_map_to_field(dmap, axis=pe_dir, format="itk", frame=0)
+    data = field.get_fdata()
+    expected = fmap_hz * trt * voxel[channel] * lps_sign
+    assert_allclose(data[..., channel], expected, atol=1e-5)
+    for other in {0, 1, 2} - {channel}:
+        assert_allclose(data[..., other], 0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("pe_dir, expected_shift", [("j", -2.0), ("j-", +2.0)])
+def test_resample_integer_voxel_shift_ras(pe_dir, expected_shift):
+    """With a constant field map chosen to displace by exactly two voxels, a
+    linear ramp resamples to that ramp shifted by exactly +-2 voxels along the
+    PE axis (linear interpolation is exact on a ramp), and only along that axis.
+    Pins the absolute correction direction/magnitude, and that ``j``/``j-`` are
+    mirror images."""
+    voxel_y = 3.0
+    affine = np.diag([2.0, voxel_y, 4.0, 1.0])
+    shape = (13, 15, 17)
+    # fmap * trt * voxel_y = 20 * 0.1 * 3 = 6 mm = 2 voxels along y
+    fmap = nib.Nifti1Image(np.full(shape, 20.0, np.float32), affine)
+    dmap = field_maps_to_displacement_maps(fmap, 0.1, pe_dir)
+    field = displacement_map_to_field(dmap, axis=pe_dir, format="itk", frame=0)
+    ramp = np.broadcast_to(
+        np.arange(shape[1], dtype=np.float32)[None, :, None], shape
+    ).copy()
+    moving = nib.Nifti1Image(ramp, affine)
+    out = resample_image(moving, moving, field).get_fdata()
+
+    # interior column along y (avoid the clamped edges), fixed x, z
+    interior = slice(4, shape[1] - 4)
+    col_in = ramp[6, interior, 8]
+    col_out = out[6, interior, 8]
+    assert_allclose(col_out - col_in, expected_shift, atol=1e-4)
+    # the off-axis planes are unchanged (no x/z displacement)
+    assert_allclose(
+        out[6, interior, 8], ramp[6, interior, 8] + expected_shift, atol=1e-4
+    )

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -210,18 +210,18 @@ def test_displacement_maps_to_field_maps_flip_sign():
 
 
 def test_displacement_map_to_field_inserts_along_axis():
-    """A scalar displacement map at axis="y" must end up entirely in the y component
-    of the resulting 3-vector field (modulo the warp-format sign flip applied for
-    the default itk output)."""
+    """A scalar displacement map at axis="y" must end up entirely in the y
+    component of the resulting 3-vector field, negated by the NIfTI-RAS ->
+    ITK-LPS y flip that displacement_map_to_field applies at the field boundary."""
     rng = np.random.default_rng(0)
     affine = np.eye(4)
     data = rng.standard_normal((4, 4, 4, 2)).astype(np.float32)
     dmap = nib.Nifti1Image(data, affine)
     field = displacement_map_to_field(dmap, axis="y", format="itk", frame=0)
     field_data = field.get_fdata().squeeze()
-    # itk format applies WARP_ITK_FLIPS["itk"] = [1, 1, 1] → identity; y component
-    # equals the source frame, x and z are zero.
-    assert_allclose(field_data[..., AXIS_MAP["y"]], data[..., 0])
+    # y (RAS axis 1) picks up the RAS->LPS flip → negated source frame; x and z
+    # are zero.
+    assert_allclose(field_data[..., AXIS_MAP["y"]], -data[..., 0])
     assert_allclose(field_data[..., AXIS_MAP["x"]], 0.0)
     assert_allclose(field_data[..., AXIS_MAP["z"]], 0.0)
 
@@ -405,12 +405,16 @@ def test_displacement_field_to_map_clears_vector_intent():
 @pytest.mark.parametrize(
     "pe_dir, expected_sign",
     [
-        ("i", -1.0),  # axis 0: itk LPS x flip
-        ("i-", +1.0),  # axis 0: "-" cancels itk flip
-        ("j", -1.0),  # axis 1: itk LPS y flip
-        ("j-", +1.0),  # axis 1: "-" cancels itk flip
-        ("k", +1.0),  # axis 2: no LPS flip
-        ("k-", -1.0),  # axis 2: just "-"
+        # Data-space convention: displacement = fmap * trt * |voxel|, signed only
+        # by the PE polarity ("-"). The NIfTI-RAS -> ITK-LPS x/y flip is applied
+        # later, at the ITK boundary (invert_displacement_maps /
+        # displacement_map_to_field), so this conversion is orientation-free.
+        ("i", +1.0),  # positive polarity
+        ("i-", -1.0),  # "-" polarity
+        ("j", +1.0),
+        ("j-", -1.0),
+        ("k", +1.0),
+        ("k-", -1.0),
     ],
 )
 def test_field_maps_to_displacement_maps_known_value(pe_dir, expected_sign):
@@ -492,9 +496,10 @@ def test_displacement_field_to_map_drops_off_axis_channels():
     rng = np.random.default_rng(0)
     field_data = rng.standard_normal((4, 4, 4, 3)).astype(np.float32)
     field = nib.Nifti1Image(field_data, affine)
-    # itk format = identity → extracted map equals the chosen channel verbatim.
+    # displacement_field_to_map undoes the RAS->LPS y flip, so the extracted map
+    # is the negated y channel (x and z channels are dropped).
     extracted_y = displacement_field_to_map(field, axis="y", format="itk").get_fdata()
-    assert_allclose(extracted_y, field_data[..., 1], atol=1e-6)
+    assert_allclose(extracted_y, -field_data[..., 1], atol=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/warpkit/utilities.py
+++ b/warpkit/utilities.py
@@ -247,18 +247,22 @@ def create_brain_mask(
 
 
 def _signed_pe_voxel_size(img: nib.Nifti1Image, phase_encoding_direction: str) -> float:
-    """Voxel size (mm) along the phase-encoding axis, signed for the EPI
-    displacement <-> field-map conversions.
+    """Voxel size (mm) along the phase-encoding axis, signed by the PE polarity.
 
-    The sign carries two conventions: a trailing ``-`` in the phase-encoding
-    direction flips the displacement direction, and the x/y axes are flipped
-    for the ITK (LPS) frame relative to NIfTI RAS.
+    A trailing ``-`` in the phase-encoding direction flips the displacement
+    direction. This is a pure data-space quantity: the displacement magnitude
+    is ``fieldmap * total_readout_time * |voxel|`` along the PE *voxel* axis,
+    with no dependence on the image's orientation.
+
+    The NIfTI-RAS -> ITK-LPS x/y flip is deliberately *not* applied here. That
+    is an ITK-frame concept, and baking it in against the raw ``axis_code`` only
+    holds when the data is stored RAS. It is applied later, at the ITK boundary
+    (``invert_displacement_maps`` / ``displacement_map_to_field``), after the
+    data has been reoriented to RAS where "axis 0 = x, axis 1 = y" is true.
     """
     axis_code = AXIS_MAP[phase_encoding_direction]
     voxel_size = img.header.get_zooms()[axis_code]  # type: ignore
     if "-" in phase_encoding_direction:
-        voxel_size *= -1
-    if axis_code == 0 or axis_code == 1:
         voxel_size *= -1
     return voxel_size
 
@@ -429,32 +433,47 @@ def displacement_map_to_field(
     nib.Nifti1Image
         Displacement field in mm
     """
-    # get the axis displacement map should insert
+    # the (data-space) axis the scalar map is composed along
     axis_code = AXIS_MAP[axis]
     displacement_map = cast(nib.Nifti1Image, displacement_map)
 
-    # check if the displacement map has multiple frames
-    if len(displacement_map.shape) == 4:
-        data = np.asarray(displacement_map.dataobj[..., frame])
+    # An ITK displacement field stores world-space (LPS) vector components, so
+    # the scalar PE displacement must land in the *world* channel for the PE
+    # direction, with the NIfTI-RAS -> ITK-LPS x/y flip applied. Build the field
+    # in RAS so that "axis 0 = x, axis 1 = y" holds, then reorient the field back
+    # to the map's original grid — world-space vector components are invariant
+    # under a pure grid relabel, so as_reoriented carries them across correctly.
+    to_canonical, from_canonical = get_ras_orient_transform(displacement_map)
+    displacement_map_ras = displacement_map.as_reoriented(to_canonical)
+
+    to_canonical_arr = np.asarray(to_canonical)
+    ras_axis_code = int(to_canonical_arr[axis_code, 0])
+    reorient_sign = float(to_canonical_arr[axis_code, 1])
+    lps_sign = -1.0 if ras_axis_code in (0, 1) else 1.0
+
+    # frame-select (spatial reorientation leaves the trailing frame axis intact)
+    if len(displacement_map_ras.shape) == 4:
+        data = np.asarray(displacement_map_ras.dataobj[..., frame])
     else:  # otherwise just get the data
-        data = displacement_map.get_fdata()
+        data = displacement_map_ras.get_fdata()
 
-    # get affine and header info
-    affine = displacement_map.affine
-    header = cast(nib.Nifti1Header, displacement_map.header)
+    header = cast(nib.Nifti1Header, displacement_map_ras.header)
 
-    # create a new array to hold the displacement field
+    # create a new array to hold the displacement field (built in RAS)
     new_data = np.zeros((*data.shape, 3), dtype=np.float32)
 
-    # insert data at axis
-    new_data[..., axis_code] = data  # type: ignore
+    # insert the scalar into the RAS world channel for the PE axis, carrying the
+    # reorient flip and the RAS->LPS flip
+    new_data[..., ras_axis_code] = data * (reorient_sign * lps_sign)  # type: ignore
 
     # set the header to the correct intent code
     # this is needed for ANTs, but has no effect on FSL/AFNI
     header.set_intent("vector")
 
-    # form the image
-    warp = nib.Nifti1Image(new_data, affine, header)
+    # form the RAS field, then return it to the map's original orientation
+    warp = nib.Nifti1Image(new_data, displacement_map_ras.affine, header).as_reoriented(
+        from_canonical
+    )
 
     # convert to whatever format is needed and return
     return convert_warp(warp, in_type="itk", out_type=format)
@@ -490,22 +509,33 @@ def displacement_field_to_map(
     axis_code = AXIS_MAP[axis]
     # Round-trip through itk so we can index the channel axis directly.
     field_itk = convert_warp(displacement_field, in_type=format, out_type="itk")
-    data = field_itk.get_fdata()
+
+    # Inverse of displacement_map_to_field: the ITK field carries world-space
+    # (LPS) components, so reorient to RAS, take the world channel for the PE
+    # direction, and undo the RAS->LPS and reorient flips to recover the
+    # data-space scalar; then reorient that scalar to the field's original grid.
+    to_canonical, from_canonical = get_ras_orient_transform(field_itk)
+    field_itk_ras = field_itk.as_reoriented(to_canonical)
+
+    to_canonical_arr = np.asarray(to_canonical)
+    ras_axis_code = int(to_canonical_arr[axis_code, 0])
+    reorient_sign = float(to_canonical_arr[axis_code, 1])
+    lps_sign = -1.0 if ras_axis_code in (0, 1) else 1.0
+
+    data = field_itk_ras.get_fdata()
     if data.ndim == 5 and data.shape[3] == 1:
         data = data[..., 0, :]
     if data.ndim != 4 or data.shape[-1] != 3:
         raise ValueError(
             f"expected a 4D 3-channel field after itk conversion; got shape {data.shape}"
         )
-    map_data = data[..., axis_code]
+    map_data = data[..., ras_axis_code] * (reorient_sign * lps_sign)
     # Drop the vector intent so downstream tools don't misread the 1-channel
     # result as a field.
-    map_header = cast(nib.Nifti1Header, field_itk.header.copy())
+    map_header = cast(nib.Nifti1Header, field_itk_ras.header.copy())
     map_header.set_intent("none", (), "")
-    return cast(
-        nib.Nifti1Image,
-        nib.Nifti1Image(map_data, field_itk.affine, map_header),
-    )
+    map_ras = nib.Nifti1Image(map_data, field_itk_ras.affine, map_header)
+    return cast(nib.Nifti1Image, map_ras.as_reoriented(from_canonical))
 
 
 def get_x_orient_transform(
@@ -591,7 +621,7 @@ def invert_displacement_maps(
     nib.Nifti1Image
         Inverted displacement maps in mm
     """
-    # get the axis that this displacement map is along
+    # get the axis (in the native data grid) this displacement map is along
     axis_code = AXIS_MAP[axis]
 
     # we convert the data to RAS, for passing into ITK
@@ -600,6 +630,24 @@ def invert_displacement_maps(
 
     # get to RAS orientation
     displacement_maps_ras = displacement_maps.as_reoriented(to_canonical)
+
+    # as_reoriented moves the grid to RAS but carries neither the PE axis index
+    # nor the sign of the (scalar, data-space) displacement values with it, and
+    # the map arriving here has *not* had the RAS->LPS flip applied yet (that
+    # was moved out of the Hz<->mm conversion). Reconstruct both here, in RAS.
+    # to_canonical[q] = (n, f) means native axis q maps to RAS axis n with flip f:
+    #   * ras_axis_code  - the RAS axis the native PE axis (axis_code) maps to.
+    #   * reorient_sign  - if that mapping flipped the axis (f == -1), "+axis"
+    #     now points the other way, so the values need negating to stay in the
+    #     +RAS-axis convention.
+    #   * lps_sign       - the NIfTI-RAS -> ITK-LPS x/y flip, valid now that we
+    #     are in RAS (axis 0 = x, axis 1 = y). Applying it keeps the C++
+    #     inverter's input identical to the historical RAS behaviour.
+    to_canonical_arr = np.asarray(to_canonical)
+    ras_axis_code = int(to_canonical_arr[axis_code, 0])
+    reorient_sign = float(to_canonical_arr[axis_code, 1])
+    lps_sign = -1.0 if ras_axis_code in (0, 1) else 1.0
+    sign = reorient_sign * lps_sign
 
     # get data
     data = displacement_maps_ras.dataobj
@@ -617,17 +665,22 @@ def invert_displacement_maps(
     logging.info("Inverting displacement maps...")
     for i_vol in range(data.shape[-1]):
         logging.info(f"Processing frame: {i_vol}")
-        # pad array with edge values so edge effects of inverse are avoided
-        mod_data = np.pad(data[..., i_vol], pad_width=1)
+        # convert the values to the ITK (LPS, +RAS-axis) convention the inverter
+        # expects, pad to avoid edge effects of the inverse, then convert back to
+        # the native data-space convention on the way out.
+        mod_data = np.pad(data[..., i_vol] * sign, pad_width=1)
 
-        new_data[..., i_vol] = invert_displacement_map_cpp(
-            mod_data,
-            translations,
-            rotations,
-            zooms,
-            axis=axis_code,
-            verbose=verbose,
-        )[1 : data.shape[0] + 1, 1 : data.shape[1] + 1, 1 : data.shape[2] + 1]
+        new_data[..., i_vol] = (
+            invert_displacement_map_cpp(
+                mod_data,
+                translations,
+                rotations,
+                zooms,
+                axis=ras_axis_code,
+                verbose=verbose,
+            )[1 : data.shape[0] + 1, 1 : data.shape[1] + 1, 1 : data.shape[2] + 1]
+            * sign
+        )
 
     # make new image in original orientation
     inv_displacement_maps = nib.Nifti1Image(

--- a/warpkit/utilities.py
+++ b/warpkit/utilities.py
@@ -457,7 +457,10 @@ def displacement_map_to_field(
     else:  # otherwise just get the data
         data = displacement_map_ras.get_fdata()
 
-    header = cast(nib.Nifti1Header, displacement_map_ras.header)
+    # copy the header before mutating its intent below: as_reoriented can return
+    # the input image unchanged (e.g. already-RAS data), so mutating its header
+    # in place would leak back to the caller's displacement map.
+    header = cast(nib.Nifti1Header, displacement_map_ras.header.copy())
 
     # create a new array to hold the displacement field (built in RAS)
     new_data = np.zeros((*data.shape, 3), dtype=np.float32)


### PR DESCRIPTION
## Summary

MEDIC only applied the distortion correction in the correct direction when the
data was stored ~RAS. Any orientation that **flipped or permuted the
phase-encode axis** was silently mis-corrected — a 48-orientation equivariance
sweep found **40/48 wrong**, with the correction applied along the wrong
physical axis (differences ~0.4 of signal scale; a zero-field control was exact,
ruling out interpolation noise).

Root cause: the NIfTI-RAS → ITK-LPS x/y sign flip was baked into the Hz↔mm
conversion (`_signed_pe_voxel_size`) against the raw `axis_code`, which only
holds for RAS storage; `invert_displacement_maps` also inverted along the
un-remapped native axis, and `displacement_map_to_field` inserted into the
native grid channel rather than the world channel.

## Fix

Move the ITK/LPS concern to the ITK boundary and remap the PE axis into the RAS
frame everywhere it's consumed:

- `_signed_pe_voxel_size` / `field_maps_to_displacement_maps` are now pure
  data-space (`fmap * trt * |voxel|`, signed only by PE polarity) — orientation
  independent.
- `invert_displacement_maps`, `displacement_map_to_field` and
  `displacement_field_to_map` reorient to RAS, remap the PE axis via
  `to_canonical[axis_code]` (native-indexed: native axis q → RAS axis n), and
  apply the RAS→LPS flip there.

## Behaviour

- **Corrected images and field maps: byte-identical** for RAS (golden-verified).
- **All 48 orientations now exactly equivariant** (worst Δ = 0.0 per base PE axis).
- **Convention change:** the returned `displacement_maps` sign flips for `i`/`j`
  PE directions (they are data-space now); corrected images and field maps are
  unaffected. Old on-disk displacement-map files predate this convention.

## Tests

- New `tests/test_orientation.py`: 48-orientation equivariance sweep × 3 PE axes,
  RAS known-value anchors (field magnitude/sign, exact integer-voxel resample
  shift), and a PED-remap oracle guard. Verified non-vacuous (reintroducing the
  bug fails 47 of them).
- Updated the map↔field / Hz↔mm convention tests in `tests/test_utilities.py`.

Full suite: **314 passed** (was 213). Ruff + pyright clean; `utilities.py` at 99%
coverage. Python-only change — no C++/pybind11/ITK/ABI impact.
