### PR TITLE
:wrench: Add codespell configuration and fix existing typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,9 @@ repos:
         entry: scripts/check-gitmoji.sh
   
   - repo: https://github.com/codespell-project/codespell
-    # Configuration for codespell is in .pre-commit-config.yaml
+    # Configuration for codespell is in pyproject.toml
     rev: v2.4.2
     hooks:
-    - id: codespell
+      - id: codespell
+        additional_dependencies:
+          - tomli; python_version<'3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         language: script
         stages: [commit-msg]
         entry: scripts/check-gitmoji.sh
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.2
+    hooks:
+    - id: codespell

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -10,7 +10,7 @@
 namespace py = pybind11;
 
 /**
- * @brief print sequnce
+ * @brief print sequence
  *
  * @tparam sequence
  * @param seq

--- a/include/warps.h
+++ b/include/warps.h
@@ -315,7 +315,7 @@ py::array_t<T, py::array::f_style> compute_jacobian_determinant(py::array_t<T, p
     typename DisplacementFieldJacobianDeterminantFilterType::Pointer jacobian_filter =
         DisplacementFieldJacobianDeterminantFilterType::New();
 
-    // Pass displacment fields into jacobian filters
+    // Pass displacement fields into jacobian filters
     jacobian_filter->SetInput(field);
     jacobian_filter->SetUseImageSpacingOff();
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ before-build = ["pip install delocate>=0.13.0"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.lock,include/romeo,include/itk,build,.venv'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.pdf,*.lock,include/romeo,include/itk,build,.venv'
 check-hidden = true
 # ignore-words-list rationale:
 #   te,tes    - MR-physics abbreviations (echo time / echo times); see CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ before-build = ["pip install delocate>=0.13.0"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = './.git,./.git-meta,./.gitignore,./.gitattributes,*.pdf,*.lock,./include/romeo/*,./include/itk/*,./build/*,./.venv/*'
+skip = './.git*,*/.git-meta/*,*.pdf,*.lock,*include/romeo/*,*include/itk/*,*/build/*,*/.venv/*'
 check-hidden = true
 # ignore-words-list rationale:
 #   te,tes    - MR-physics abbreviations (echo time / echo times); see CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,10 @@ archs = ["auto"]
 archs = ["universal2"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 before-build = ["pip install delocate>=0.13.0"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,12 @@ before-build = ["pip install delocate>=0.13.0"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.lock'
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.lock,include/romeo,include/itk,build,.venv'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# ignore-words-list rationale:
+#   te,tes    - MR-physics abbreviations (echo time / echo times); see CLAUDE.md
+#   nd        - DICOM ImageType flag in BIDS test fixtures
+#   datas     - PyInstaller Analysis() parameter name (packaging/pyinstaller/)
+#   framei    - loop variable "frame i" in tests/test_distortion.py
+#   thirdparty - refers to ITK's ThirdParty/Eigen3 module in CMakeLists.txt comment
+ignore-words-list = 'te,tes,nd,datas,framei,thirdparty'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ before-build = ["pip install delocate>=0.13.0"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.git-meta,.gitignore,.gitattributes,*.pdf,*.lock,include/romeo,include/itk,build,.venv'
+skip = './.git,./.git-meta,./.gitignore,./.gitattributes,*.pdf,*.lock,./include/romeo/*,./include/itk/*,./build/*,./.venv/*'
 check-hidden = true
 # ignore-words-list rationale:
 #   te,tes    - MR-physics abbreviations (echo time / echo times); see CLAUDE.md

--- a/warpkit/concurrency.py
+++ b/warpkit/concurrency.py
@@ -93,7 +93,7 @@ def run_executor(
     for future in as_completed(futures):
         # get the index of the future
         idx = futures[future]
-        # pass thre result of the future to the post_fn
+        # pass the result of the future to the post_fn
         if post_fn is not None:
             post_fn(idx, future.result())
 

--- a/warpkit/unwrap.py
+++ b/warpkit/unwrap.py
@@ -408,7 +408,7 @@ def unwrap_phase(
             npt.NDArray[np.bool_], binary_dilation(combined_mask, strel, iterations=2)
         )
 
-        # get a dilated verision of the mask
+        # get a dilated version of the mask
         combined_mask_dilated = cast(
             npt.NDArray[np.bool_],
             binary_dilation(combined_mask, strel, iterations=automask_dilation),
@@ -533,7 +533,7 @@ def check_temporal_consistency_corr(
     # get the correlation between the current frame and all other frames
     corr = corr2_coeff(current_frame_data, unwrapped_echo_1[brain_mask, :]).ravel()
 
-    # threhold the RD
+    # threshold the RD
     tmask = corr > threshold
 
     # get indices of mask
@@ -653,7 +653,7 @@ def compute_offset(
     # compute closest multiple of 2pi to the difference
     int_map = np.round(y_diff / (2 * np.pi)).astype(int)
 
-    # compute the most often occuring multiple
+    # compute the most often occurring multiple
     best_offset = mode(int_map, axis=0, keepdims=False).mode
     best_offset = cast(int, best_offset)
 

--- a/warpkit/utilities.py
+++ b/warpkit/utilities.py
@@ -286,7 +286,7 @@ def field_maps_to_displacement_maps(
     Returns
     -------
     nib.Nifti1Image
-        Displacment maps in mm
+        Displacement maps in mm
     """
     voxel_size = _signed_pe_voxel_size(field_maps, phase_encoding_direction)
 


### PR DESCRIPTION
Add [codespell](https://github.com/codespell-project/codespell) spell-checking to warpkit.

## Summary

- Wire codespell into CI (`.github/workflows/codespell.yml`) and pre-commit.
- Tune the config in `[tool.codespell]` (pyproject.toml) so the domain vocabulary (MR-physics terms, PyInstaller API, DICOM/BIDS metadata, vendored ROMEO port) does not produce false positives.
- Fix the 7 real typos that codespell surfaced (all in comments/docstrings — no user-facing strings, identifiers, or public API touched).

Result: `codespell` passes with zero errors on the tree.

## Config choices

<details>
<summary>Skip patterns and ignore-words-list rationale</summary>

**Skip** — all `./`-anchored so they match the paths codespell walks when invoked as `codespell .`:

- `./include/romeo/*`, `./include/itk/*` — vendored code (do not modify upstream)
- `./build/*`, `./.venv/*` — build / venv artifacts
- `./.git`, `./.git-meta`, `./.gitignore`, `./.gitattributes` — VCS metadata (`.git-meta/` is a per-developer scratch dir for draft commit messages, which naturally contain typos-under-discussion)
- `*.pdf`, `*.lock` — binary / generated

**ignore-words-list** (documented in-file with rationale):

| word         | reason                                                                       |
| ------------ | ---------------------------------------------------------------------------- |
| `te`, `tes`  | MR-physics abbreviations for echo time / echo times (see CLAUDE.md)          |
| `nd`         | DICOM `ImageType` flag ("Normalized Distortion-corrected") in BIDS fixtures  |
| `datas`      | PyInstaller `Analysis()` parameter name in `packaging/pyinstaller/`          |
| `framei`     | `frame_i` loop variable in `tests/test_distortion.py`                        |
| `thirdparty` | Refers to ITK's `ThirdParty/Eigen3` module in a CMakeLists.txt comment       |

</details>

<details>
<summary>Typos fixed (comments/docstrings only)</summary>

| file                    | before        | after          | note                                                              |
| ----------------------- | ------------- | -------------- | ----------------------------------------------------------------- |
| `include/utilities.h`   | `sequnce`     | `sequence`     | `@brief` comment                                                  |
| `include/warps.h`       | `displacment` | `displacement` | `// Pass displacement fields ...` comment                         |
| `warpkit/concurrency.py`| `thre`        | `the`          | "pass the result of the future" — ambiguous per codespell, clear from context |
| `warpkit/unwrap.py`     | `verision`    | `version`      | "dilated version of the mask" — ambiguous per codespell, clear from context |
| `warpkit/unwrap.py`     | `threhold`    | `threshold`    | "threshold the RD" comment                                        |
| `warpkit/unwrap.py`     | `occuring`    | `occurring`    | "most often occurring multiple" comment                           |
| `warpkit/utilities.py`  | `Displacment` | `Displacement` | docstring return-value description                                |

All fixes reviewed line-by-line: none touch identifiers, API surface, string literals, or regex patterns.

</details>

<details>
<summary>Extended-dictionary pass (for future auditors)</summary>

`codespell --builtin clear,rare,usage,code,names` was run as a follow-up audit. All remaining hits are false positives (real domain terms) and are left untouched:

- `sinc` (`include/warps.h`) — the sinc interpolator
- `arange` (tests) — `np.arange`
- `iff` (tests) — mathematical "if and only if"
- `ba` (`warpkit/utilities.py`) — SciPy `iirfilter(output="ba")` convention
- `master` in `tests/test_romeo.py` and `tests/data/test_data/*.json` — legitimate references to ROMEO.jl's `master` branch and Siemens scanner sequence metadata, respectively

Not adding these to `ignore-words-list` since CI uses only the default `clear,rare` dictionaries where none are flagged.

</details>

## Historical context

The project has had prior manual typo-fix commits (`:memo: fix typo in import in README`, `:memo: fix README typo`) — automated checking replaces the ad-hoc process.

## Testing

- `uvx codespell` — passes with exit 0
- `uvx pre-commit run --files <changed>` — ruff-check, ruff-format, codespell all pass (pyright reports missing-import errors due to my local env not having the compiled extension + Python deps; unrelated to these changes, which only touch comments/docstrings)

## CI safety

The workflow uses `permissions: contents: read` and pins `codespell-project/actions-codespell` to a full commit SHA (`v2.2`).
